### PR TITLE
ADAM/GATK pipeline, first cut

### DIFF
--- a/src/toil_scripts/adam_gatk_pipeline/align_and_call.py
+++ b/src/toil_scripts/adam_gatk_pipeline/align_and_call.py
@@ -133,10 +133,15 @@ def build_parser():
     parser.add_argument('-U', '--uuid', required = True,
                         help = 'Sample UUID.')
 
+    # what pipeline are we running
+    parser.add_argument('-PR', '--pipeline_to_run',
+                        help = "Whether we should run 'adam', 'gatk', or 'both'. Default is 'both'.",
+                        default = 'both')
+
     # add bucket args
     parser.add_argument('-3', '--s3_bucket', required = True,
                         help = 'S3 Bucket URI')
-    parser.add_argument('-3r', '--bucket_region', default = "us-east-1",
+    parser.add_argument('-3r', '--bucket_region', default = "us-west-2",
                         help = 'Region of the S3 bucket. Defaults to us-east-1.')
     parser.add_argument('-y', '--aws_access_key', required = True,
                         help = 'Amazon web services access key')
@@ -193,7 +198,7 @@ def build_parser():
     # return built parser
     return parser
 
-def static_dag(job, s3_bucket, uuid, bwa_inputs, adam_inputs, gatk_preprocess_inputs, gatk_adam_call_inputs, gatk_gatk_call_inputs):
+def static_dag(job, bucket_region, s3_bucket, uuid, bwa_inputs, adam_inputs, gatk_preprocess_inputs, gatk_adam_call_inputs, gatk_gatk_call_inputs, pipeline_to_run):
     """
     Prefer this here as it allows us to pull the job functions from other jobs
     without rewrapping the job functions back together.
@@ -237,7 +242,7 @@ def static_dag(job, s3_bucket, uuid, bwa_inputs, adam_inputs, gatk_preprocess_in
     # write config for GATK haplotype caller for the result of ADAM preprocessing
     gatk_adam_call_config_path = os.path.join(work_dir, "%s_gatk_adam_call_config.csv" % uuid)
     gatk_adam_call_fp = open(gatk_adam_call_config_path, "w")
-    print >> gatk_adam_call_fp, "%s,https://s3%s.amazonaws.com/%s/analysis/%s.adam.bam" % (uuid, bucket_region, s3_bucket, uuid)
+    print >> gatk_adam_call_fp, "%s,https://s3%s.amazonaws.com/%s/analysis/%s/%s.adam.bam" % (uuid, bucket_region, s3_bucket, uuid, uuid)
     gatk_adam_call_fp.flush()
     gatk_adam_call_fp.close()
     gatk_adam_call_inputs['config'] = job.fileStore.writeGlobalFile(gatk_adam_call_config_path)
@@ -245,37 +250,43 @@ def static_dag(job, s3_bucket, uuid, bwa_inputs, adam_inputs, gatk_preprocess_in
     # write config for GATK haplotype caller for the result of GATK preprocessing
     gatk_gatk_call_config_path = os.path.join(work_dir, "%s_gatk_gatk_call_config.csv" % uuid)
     gatk_gatk_call_fp = open(gatk_gatk_call_config_path, "w")
-    print >> gatk_gatk_call_fp, "%s,https://s3%s.amazonaws.com/%s/analysis/%s.gatk.bam" % (uuid, bucket_region, s3_bucket, uuid)
+    print >> gatk_gatk_call_fp, "%s,https://s3%s.amazonaws.com/%s/analysis/%s/%s.gatk.bam" % (uuid, bucket_region, s3_bucket, uuid, uuid)
     gatk_gatk_call_fp.flush()
     gatk_gatk_call_fp.close()
     gatk_gatk_call_inputs['config'] = job.fileStore.writeGlobalFile(gatk_gatk_call_config_path)
 
     # get head BWA alignment job function and encapsulate it
-    bwa = job.wrapJobFn(toil_scripts.batch_alignment.bwa_alignment.download_shared_files,
+    bwa = job.wrapJobFn(download_shared_files,
                         bwa_inputs).encapsulate()
 
     # get head ADAM preprocessing job function and encapsulate it
-    adam_preprocess = job.wrapJobFn(toil_scripts.adam_pipeline.spark_toil_script.start_master,
+    adam_preprocess = job.wrapJobFn(start_master,
                                     adam_inputs).encapsulate()
 
     # get head GATK preprocessing job function and encapsulate it
-    gatk_preprocess = job.wrapJobFn(toil_scripts.gatk_processing.download_shared_files,
+    gatk_preprocess = job.wrapJobFn(download_gatk_files,
                                     gatk_preprocess_inputs).encapsulate()
 
     # get head GATK haplotype caller job function for the result of ADAM preprocessing and encapsulate it
-    gatk_adam_call = job.wrapJobFn(toil_scripts.gatk_germline.germline.batch_start,
+    gatk_adam_call = job.wrapJobFn(batch_start,
                                    gatk_adam_call_inputs).encapsulate()
 
     # get head GATK haplotype caller job function for the result of GATK preprocessing and encapsulate it
-    gatk_gatk_call = job.wrapJobFn(toil_scripts.gatk_germline.germline.batch_start,
+    gatk_gatk_call = job.wrapJobFn(batch_start,
                                    gatk_gatk_call_inputs).encapsulate()
 
     # wire up dag
     job.addChild(bwa)
-    bwa.addChild(adam_preprocess)
-    adam_preprocess.addChild(gatk_adam_call)
-    bwa.addChild(gatk_preprocess)
-    gatk_preprocess.addChild(gatk_gatk_call)
+    
+    if (pipeline_to_run == "adam" or
+        pipeline_to_run == "both"):
+        bwa.addChild(adam_preprocess)
+        adam_preprocess.addChild(gatk_adam_call)
+
+    if (pipeline_to_run == "gatk" or
+        pipeline_to_run == "both"):
+        bwa.addChild(gatk_preprocess)
+        gatk_preprocess.addChild(gatk_gatk_call)
 
 if __name__ == '__main__':
     
@@ -303,15 +314,19 @@ if __name__ == '__main__':
                   'aws_access_key':  args.aws_access_key,
                   'aws_secret_key':  args.aws_secret_key}
     
+    if args.num_nodes <= 1:
+        raise ValueError("--num_nodes allocates one Spark/HDFS master and n-1 workers, and thus must be greater than 1. %d was passed." % args.num_nodes)
+
     adam_inputs = {'numWorkers': args.num_nodes - 1,
-                   'outDir':     's3://%s/analysis/%s.bam' % (args.s3_bucket, args.uuid),
+                   'outDir':     's3://%s/analysis/%s' % (args.s3_bucket, args.uuid),
                    'knownSNPs':  args.dbsnp.replace("https://s3-us-west-2.amazonaws.com/", "s3://"),
                    'accessKey':  args.aws_access_key,
                    'secretKey':  args.aws_secret_key,
                    'driverMemory': args.driver_memory,
                    'executorMemory': args.executor_memory,
                    'sudo': args.sudo,
-                   'bamName': 's3://%s/alignment/%s.bam' % (args.s3_bucket, args.uuid)}
+                   'bamName': 's3://%s/alignment/%s.bam' % (args.s3_bucket, args.uuid),
+                   'suffix': '.adam'}
 
     gatk_preprocess_inputs = {'ref.fa': args.ref,
                               'phase.vcf': args.phase,
@@ -322,9 +337,9 @@ if __name__ == '__main__':
                               'ssec': None,
                               'cpu_count': str(multiprocessing.cpu_count()),
                               'suffix': '.gatk',
-                              's3_dir': "%s/%s/analysis" % (args.s3_bucket, args.uuid),}
+                              's3_dir': "%s/analysis/%s" % (args.s3_bucket, args.uuid),}
     
-    gatk_adam_call_inputs = {'ref.fa': args.ref,
+    gatk_adam_call_inputs = {'ref.fa': args.ref.replace('.fa', '.sorted.fa'),
                              'phase.vcf': args.phase,
                              'mills.vcf': args.mills,
                              'dbsnp.vcf': args.dbsnp,
@@ -334,11 +349,12 @@ if __name__ == '__main__':
                              'uuid': None,
                              'cpu_count': str(multiprocessing.cpu_count()),
                              'ssec': None,
-                             's3_dir': "%s/%s/analysis" % (args.s3_bucket, args.uuid),
+                             's3_dir': "%s/analysis/%s" % (args.s3_bucket, args.uuid),
                              'file_size': args.file_size,
                              'aws_access_key':  args.aws_access_key,
                              'aws_secret_key':  args.aws_secret_key,
-                             'suffix': '.adam'}
+                             'suffix': '.adam',
+                             'sudo': args.sudo}
 
     gatk_gatk_call_inputs = {'ref.fa': args.ref,
                              'phase.vcf': args.phase,
@@ -350,17 +366,25 @@ if __name__ == '__main__':
                              'uuid': None,
                              'cpu_count': str(multiprocessing.cpu_count()),
                              'ssec': None,
-                             's3_dir': "%s/%s/analysis" % (args.s3_bucket, args.uuid),
+                             's3_dir': "%s/analysis/%s" % (args.s3_bucket, args.uuid),
                              'file_size': args.file_size,
                              'aws_access_key':  args.aws_access_key,
                              'aws_secret_key':  args.aws_secret_key,
-                             'suffix': '.gatk'}
+                             'suffix': '.gatk',
+                             'sudo': args.sudo}
+
+    if (args.pipeline_to_run != "adam" and
+        args.pipeline_to_run != "gatk" and
+        args.pipeline_to_run != "both"):
+        raise ValueError("--pipeline_to_run must be either 'adam', 'gatk', or 'both'. %s was passed." % args.pipeline_to_run)
 
     Job.Runner.startToil(Job.wrapJobFn(static_dag,
+                                       args.bucket_region,
                                        args.s3_bucket,
                                        args.uuid,
                                        bwa_inputs,
                                        adam_inputs,
                                        gatk_preprocess_inputs,
                                        gatk_adam_call_inputs,
-                                       gatk_gatk_call_inputs), args)
+                                       gatk_gatk_call_inputs,
+                                       args.pipeline_to_run), args)

--- a/src/toil_scripts/adam_gatk_pipeline/align_and_call.py
+++ b/src/toil_scripts/adam_gatk_pipeline/align_and_call.py
@@ -365,7 +365,7 @@ if __name__ == '__main__':
                               'cpu_count': str(multiprocessing.cpu_count()),
                               'suffix': '.gatk' }
     
-    gatk_adam_call_inputs = {'ref.fa': args.ref.replace('.fa', '.sorted.fa'),
+    gatk_adam_call_inputs = {'ref.fa': args.ref,
                              'phase.vcf': args.phase,
                              'mills.vcf': args.mills,
                              'dbsnp.vcf': args.dbsnp,

--- a/src/toil_scripts/adam_gatk_pipeline/align_and_call.py
+++ b/src/toil_scripts/adam_gatk_pipeline/align_and_call.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python2.7
+"""
+@author Frank Austin Nothaft fnothaft@berkeley.edu
+@date 12/30/2015
+
+Pipeline to go from FASTQ to VCF using both the ADAM+HaplotypeCaller pipeline
+as well as the GATK best practices pipeline.
+
+This doesn't contain the GATK best practices pipeline yet though. More work TBD.
+
+        0 --> 1 --> 2 --> 3 --> 4 --> 5
+                                      |++(6)
+                                      7 --> 9 --> 10 --> 11 --> 12 <snip1>
+                                       ++(8)
+
+        <snip1 /> 12 --> 13 --> 14 --> 15 --> 16 --> 17
+                                                     |
+                                                     18
+                                                    /  \
+                                                  19    20
+                                                 /        \
+                                               21          22
+
+0   bwa alignment to a reference
+1   samtools sam to bam conversion (no sort)
+2   Fix header
+3   Add read groups
+4   Upload to S3
+5   Start master
+6   Master Service
+7   Start Workers
+8   Worker Service
+9   Download Data
+10  ADAM Convert
+11  ADAM Transform
+12  Upload Data
+13  Start GATK box
+14  Download reference
+15  Index reference
+16  Build reference dictionary
+17  Index samples
+18  Run HaplotypeCaller
+19  Run VQSR on SNPs
+20  Run VQSR on INDELs
+21  Apply VQSR model to SNPs
+22  Apply VQSR model to INDELs
+
+However, the pipeline in this file is actually just three encapsulated jobs:
+
+        A --> B --> C
+
+A  Run BWA (jobs 0-4)
+B  Run ADAM (jobs 5-12)
+C  Run GATK (jobs 13-22)
+
+Those hypens should be en dashes. Alas, TIL (2/1/16) that Python does not like
+non-ASCII text in comments.
+
+===================================================================
+:Dependencies:
+curl            - apt-get install curl
+Toil            - pip install --pre toil
+Docker          - http://docs.docker.com/engine/installation/
+
+Optional:
+S3AM            - pip install --s3am (requires ~/.boto config file)
+"""
+
+# import from python system libraries
+import argparse
+import multiprocessing
+import os
+
+# import toil features
+from toil.job import Job
+
+# import job steps from other toil pipelines
+from toil_scripts.adam_pipeline.spark_toil_script import *
+from toil_scripts.batch_alignment.bwa_alignment import *
+from toil_scripts.gatk_germline.germline import *
+
+def build_parser():
+
+    parser = argparse.ArgumentParser()
+
+    # add sample uuid
+    parser.add_argument('-U', '--uuid', required = True,
+                        help = 'Sample UUID.')
+
+    # add bucket args
+    parser.add_argument('-3', '--s3_bucket', required = True,
+                        help = 'S3 Bucket URI')
+    parser.add_argument('-3r', '--bucket_region', default = "us-east-1",
+                        help = 'Region of the S3 bucket. Defaults to us-east-1.')
+    parser.add_argument('-y', '--aws_access_key', required = True,
+                        help = 'Amazon web services access key')
+    parser.add_argument('-S', '--aws_secret_key', required = True,
+                        help = 'Amazon web services secret key')
+
+    # add file size argument
+    parser.add_argument('-se', '--file_size', default = '100G',
+                        help = 'Approximate input file size. Should be given as %d[TGMK], e.g., for a 100 gigabyte file, use --file_size 100G')
+
+    # add bwa args
+    parser.add_argument('-r', '--ref', required = True,
+                        help = 'Reference fasta file')
+    parser.add_argument('-m', '--amb', required = True,
+                        help = 'Reference fasta file (amb)')
+    parser.add_argument('-n', '--ann', required = True,
+                        help = 'Reference fasta file (ann)')
+    parser.add_argument('-b', '--bwt', required = True,
+                        help = 'Reference fasta file (bwt)')
+    parser.add_argument('-p', '--pac', required = True,
+                        help = 'Reference fasta file (pac)')
+    parser.add_argument('-a', '--sa', required = True,
+                        help = 'Reference fasta file (sa)')
+    parser.add_argument('-f', '--fai', required = True,
+                        help = 'Reference fasta file (fai)')
+    parser.add_argument('-u', '--sudo', dest = 'sudo', action = 'store_true',
+                        help = 'Docker usually needs sudo to execute '
+                        'locally, but not''when running Mesos '
+                        'or when a member of a Docker group.')
+    parser.add_argument('-k', '--use_bwakit', action='store_true', help='Use bwakit instead of the binary build of bwa')
+    parser.add_argument('-t', '--alt', required=False, help='Alternate file for reference build (alt). Necessary for alt aware alignment.')
+    parser.set_defaults(sudo = False)
+
+    # add ADAM args
+    parser.add_argument('-N', '--num_nodes', type = int, required = True,
+                        help = 'Number of nodes to use')
+    parser.add_argument('-d', '--driver_memory', required = True,
+                        help = 'Amount of memory to allocate for Spark Driver.')
+    parser.add_argument('-q', '--executor_memory', required = True,
+                        help = 'Amount of memory to allocate per Spark Executor.')
+
+    # add GATK args
+    parser.add_argument('-P', '--phase', required = True,
+                        help = '1000G_phase1.indels.b37.vcf URL')
+    parser.add_argument('-M', '--mills', required = True,
+                        help = 'Mills_and_1000G_gold_standard.indels.b37.vcf URL')
+    parser.add_argument('-s', '--dbsnp', required = True,
+                        help = 'dbsnp_137.b37.vcf URL')
+    parser.add_argument('-O', '--omni', required = True,
+                        help = '1000G_omni.5.b37.vcf URL')
+    parser.add_argument('-H', '--hapmap', required = True,
+                        help = 'hapmap_3.3.b37.vcf URL')
+    
+    # return built parser
+    return parser
+
+def static_dag(job, s3_bucket, bucket_region, uuid, bwa_inputs, adam_inputs, gatk_inputs):
+    """
+    Prefer this here as it allows us to pull the job functions from other jobs
+    without rewrapping the job functions back together.
+
+    bwa_inputs: Input arguments to be passed to BWA.
+    adam_inputs: Input arguments to be passed to ADAM.
+    gatk_inputs: Input arguments to be passed to the GATK.
+    """
+
+    # get work directory
+    work_dir = job.fileStore.getLocalTempDir()
+
+    # what region is our bucket in?
+    if bucket_region == "us-east-1":
+        bucket_region = ""
+    else:
+        bucket_region = "-%s" % bucket_region
+
+    # does the work directory exist?
+    if not os.path.exists(work_dir):
+        os.mkdirs(work_dir)
+
+    # write config for bwa
+    bwa_config_path = os.path.join(work_dir, "%s_bwa_config.csv" % uuid)
+    bwafp = open(bwa_config_path, "w")
+    print >> bwafp, "%s,https://s3%s.amazonaws.com/%s/sequence/%s_1.fastq.gz,https://s3%s.amazonaws.com/%s/sequence/%s_2.fastq.gz" % (uuid, bucket_region, s3_bucket, uuid, bucket_region, s3_bucket, uuid)
+    bwafp.flush()
+    bwafp.close()
+    bwa_inputs['config'] = job.fileStore.writeGlobalFile(bwa_config_path)
+
+    # write config for gatk
+    gatk_config_path = os.path.join(work_dir, "%s_gatk_config.csv" % uuid)
+    gatkfp = open(gatk_config_path, "w")
+    print >> gatkfp, "%s,https://s3%s.amazonaws.com/%s/analysis/%s.bam" % (uuid, bucket_region, s3_bucket, uuid)
+    gatkfp.flush()
+    gatkfp.close()
+    gatk_inputs['config'] = job.fileStore.writeGlobalFile(gatk_config_path)
+    
+    # get head bwa job function and encapsulate it
+    bwa = job.wrapJobFn(download_shared_files,
+                        bwa_inputs).encapsulate()
+
+    # get head ADAM job function and encapsulate it
+    adam = job.wrapJobFn(start_master,
+                         adam_inputs).encapsulate()
+    
+    # get head GATK job function and encapsulate it
+    gatk = job.wrapJobFn(batch_start,
+                         gatk_inputs).encapsulate()
+
+    # wire up dag
+    job.addChild(bwa)
+    bwa.addChild(adam)
+    adam.addChild(gatk)
+
+if __name__ == '__main__':
+    
+    args_parser = build_parser()
+    Job.Runner.addToilOptions(args_parser)
+    args = args_parser.parse_args()
+
+    bwa_inputs = {'ref.fa': args.ref,
+                  'ref.fa.amb': args.amb,
+                  'ref.fa.ann': args.ann,
+                  'ref.fa.bwt': args.bwt,
+                  'ref.fa.pac': args.pac,
+                  'ref.fa.sa': args.sa,
+                  'ref.fa.fai': args.fai,
+                  'ref.fa.alt': args.alt,
+                  'ssec': None,
+                  'output_dir': None,
+                  'sudo': args.sudo,
+                  's3_dir': "%s/alignment" % args.s3_bucket,
+                  'lb': args.uuid,
+                  'uuid': args.uuid,
+                  'cpu_count': None,
+                  'file_size': args.file_size,
+                  'use_bwakit': args.use_bwakit,
+                  'aws_access_key':  args.aws_access_key,
+                  'aws_secret_key':  args.aws_secret_key}
+    
+    adam_inputs = {'numWorkers': args.num_nodes - 1,
+                   'outDir':     's3://%s/analysis/%s.bam' % (args.s3_bucket, args.uuid),
+                   'knownSNPs':  args.dbsnp.replace("https://s3-us-west-2.amazonaws.com/", "s3://"),
+                   'accessKey':  args.aws_access_key,
+                   'secretKey':  args.aws_secret_key,
+                   'driverMemory': args.driver_memory,
+                   'executorMemory': args.executor_memory,
+                   'sudo': args.sudo,
+                   'bamName': 's3://%s/alignment/%s.bam' % (args.s3_bucket, args.uuid)}
+
+    gatk_inputs = {'ref.fa': args.ref,
+                   'phase.vcf': args.phase,
+                   'mills.vcf': args.mills,
+                   'dbsnp.vcf': args.dbsnp,
+                   'hapmap.vcf': args.hapmap,
+                   'omni.vcf': args.omni,
+                   'output_dir': None,
+                   'uuid': None,
+                   'cpu_count': str(multiprocessing.cpu_count()),
+                   'ssec': None,
+                   's3_dir': "%s/%s/analysis" % (args.s3_bucket, args.uuid),
+                   'file_size': args.file_size,
+                   'aws_access_key':  args.aws_access_key,
+                   'aws_secret_key':  args.aws_secret_key}
+
+    Job.Runner.startToil(Job.wrapJobFn(static_dag,
+                                       args.s3_bucket,
+                                       args.bucket_region,
+                                       args.uuid,
+                                       bwa_inputs,
+                                       adam_inputs,
+                                       gatk_inputs), args)

--- a/src/toil_scripts/adam_gatk_pipeline/call_vs_grch38.sh
+++ b/src/toil_scripts/adam_gatk_pipeline/call_vs_grch38.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -x -v
+
+# Frank Austin Nothaft, fnothaft@berkeley.edu
+#
+# Pipeline for alt-aware alignment against the GRCh38 build used in the 1000G vs. b38 recompute,
+# followed by preprocessing using ADAM, and variant calling using the HaplotypeCaller.
+#
+# Precautionary step: Create location where jobStore and tmp files will exist and set TOIL_HOME.
+
+# Execution of pipeline
+python -m toil_scripts.adam_gatk_pipeline.align_and_call \
+    aws:us-west-2:fnothaft-toil-jobstore \
+    --retryCount 1 \
+    --uuid SRR062640 \
+    --s3_bucket fnothaft-fc-test-west-2 \
+    --bucket_region us-west-2 \
+    --aws_access_key ${FC_AWS_ACCESS_KEY_ID} \
+    --aws_secret_key ${FC_AWS_SECRET_ACCESS_KEY} \
+    --ref https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa \
+    --amb https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.amb \
+    --ann https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.ann \
+    --bwt https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.bwt \
+    --pac https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.pac \
+    --sa https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.sa \
+    --fai https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.fai \
+    --alt https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.alt \
+    --use_bwakit \
+    --num_nodes 1 \
+    --driver_memory 50g \
+    --executor_memory 50g \
+    --phase https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/ALL.wgs.1000G_phase3.GRCh38.ncbi_remapper.20150424.shapeit2_indels.vcf.gz \
+    --mills https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/Mills_and_1000G_gold_standard.indels.b38.primary_assembly.vcf.gz \
+    --dbsnp https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/ALL_20141222.dbSNP142_human_GRCh38.snps.vcf.gz \
+    --omni https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/ALL.wgs.1000G_phase3.GRCh38.ncbi_remapper.20150424.shapeit2_indels.vcf.gz \
+    --hapmap https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/ALL_20141222.dbSNP142_human_GRCh38.snps.vcf.gz \
+    --batchSystem=mesos \
+    --mesosMaster $(hostname -i):5050 \
+    --workDir /var/lib/toil \
+    --file_size 1G \
+    --logInfo

--- a/src/toil_scripts/adam_gatk_pipeline/call_vs_grch38.sh
+++ b/src/toil_scripts/adam_gatk_pipeline/call_vs_grch38.sh
@@ -10,10 +10,9 @@ set -x -v
 
 python -m toil_scripts.adam_gatk_pipeline.align_and_call \
     aws:us-west-2:fnothaft-toil-jobstore-new \
-    --restart \
     --retryCount 1 \
-    --uuid SRR062643 \
-    --s3_bucket fnothaft-fc-test-west-2 \
+    --uuid_manifest my_manifest_file \
+    --s3_bucket paschall-fc-test-west-2 \
     --bucket_region us-west-2 \
     --aws_access_key ${FC_AWS_ACCESS_KEY_ID} \
     --aws_secret_key ${FC_AWS_SECRET_ACCESS_KEY} \

--- a/src/toil_scripts/adam_gatk_pipeline/call_vs_grch38.sh
+++ b/src/toil_scripts/adam_gatk_pipeline/call_vs_grch38.sh
@@ -5,11 +5,9 @@ set -x -v
 # Frank Austin Nothaft, fnothaft@berkeley.edu
 #
 # Pipeline for alt-aware alignment against the GRCh38 build used in the 1000G vs. b38 recompute,
-# followed by preprocessing using ADAM, and variant calling using the HaplotypeCaller.
-#
-# Precautionary step: Create location where jobStore and tmp files will exist and set TOIL_HOME.
+# preprocessing using ADAM followed by variant calling using GATK HaplotypeCaller, and preprocessing
+# using GATK followed by variant calling using GATK HaplotypeCaller.
 
-# Execution of pipeline
 python -m toil_scripts.adam_gatk_pipeline.align_and_call \
     aws:us-west-2:fnothaft-toil-jobstore \
     --retryCount 1 \
@@ -40,3 +38,4 @@ python -m toil_scripts.adam_gatk_pipeline.align_and_call \
     --workDir /var/lib/toil \
     --file_size 1G \
     --logInfo
+

--- a/src/toil_scripts/adam_gatk_pipeline/call_vs_grch38.sh
+++ b/src/toil_scripts/adam_gatk_pipeline/call_vs_grch38.sh
@@ -9,13 +9,13 @@ set -x -v
 # using GATK followed by variant calling using GATK HaplotypeCaller.
 
 python -m toil_scripts.adam_gatk_pipeline.align_and_call \
-    aws:us-west-2:fnothaft-toil-jobstore-new \
+    ${JOBSTORE} \
     --retryCount 1 \
     --uuid_manifest my_manifest_file \
-    --s3_bucket paschall-fc-test-west-2 \
-    --bucket_region us-west-2 \
-    --aws_access_key ${FC_AWS_ACCESS_KEY_ID} \
-    --aws_secret_key ${FC_AWS_SECRET_ACCESS_KEY} \
+    --s3_bucket ${BUCKET} \
+    --bucket_region ${REGION} \
+    --aws_access_key ${AWS_ACCESS_KEY_ID} \
+    --aws_secret_key ${AWS_SECRET_ACCESS_KEY} \
     --ref https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa \
     --amb https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.amb \
     --ann https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.ann \

--- a/src/toil_scripts/adam_gatk_pipeline/call_vs_grch38.sh
+++ b/src/toil_scripts/adam_gatk_pipeline/call_vs_grch38.sh
@@ -9,33 +9,34 @@ set -x -v
 # using GATK followed by variant calling using GATK HaplotypeCaller.
 
 python -m toil_scripts.adam_gatk_pipeline.align_and_call \
-    aws:us-west-2:fnothaft-toil-jobstore \
+    aws:us-west-2:fnothaft-toil-jobstore-new \
+    --restart \
     --retryCount 1 \
-    --uuid SRR062640 \
+    --uuid SRR062643 \
     --s3_bucket fnothaft-fc-test-west-2 \
     --bucket_region us-west-2 \
     --aws_access_key ${FC_AWS_ACCESS_KEY_ID} \
     --aws_secret_key ${FC_AWS_SECRET_ACCESS_KEY} \
-    --ref https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa \
-    --amb https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.amb \
-    --ann https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.ann \
-    --bwt https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.bwt \
-    --pac https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.pac \
-    --sa https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.sa \
-    --fai https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.fai \
-    --alt https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.alt \
+    --ref https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa \
+    --amb https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.amb \
+    --ann https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.ann \
+    --bwt https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.bwt \
+    --pac https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.pac \
+    --sa https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.sa \
+    --fai https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.fai \
+    --alt https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.alt \
     --use_bwakit \
-    --num_nodes 1 \
-    --driver_memory 50g \
-    --executor_memory 50g \
-    --phase https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/ALL.wgs.1000G_phase3.GRCh38.ncbi_remapper.20150424.shapeit2_indels.vcf.gz \
-    --mills https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/Mills_and_1000G_gold_standard.indels.b38.primary_assembly.vcf.gz \
-    --dbsnp https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/ALL_20141222.dbSNP142_human_GRCh38.snps.vcf.gz \
-    --omni https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/ALL.wgs.1000G_phase3.GRCh38.ncbi_remapper.20150424.shapeit2_indels.vcf.gz \
-    --hapmap https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/ALL_20141222.dbSNP142_human_GRCh38.snps.vcf.gz \
+    --num_nodes 2 \
+    --driver_memory 200 \
+    --executor_memory 200 \
+    --phase https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/1000G_phase1.snps.high_confidence.grch38.reordered.vcf \
+    --mills https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/Mills_and_1000G_gold_standard.indels.grch38.reordered.vcf \
+    --dbsnp https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/ALL_20141222.dbSNP142_human_GRCh38.snps.vcf \
+    --omni https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/1000G_omni2.5.grch38.reordered.vcf \
+    --hapmap https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/hapmap_3.3.grch38.reordered.vcf \
     --batchSystem=mesos \
     --mesosMaster $(hostname -i):5050 \
     --workDir /var/lib/toil \
     --file_size 1G \
-    --logInfo
-
+    --logInfo \
+    --clean never

--- a/src/toil_scripts/adam_gatk_pipeline/my_manifest_file
+++ b/src/toil_scripts/adam_gatk_pipeline/my_manifest_file
@@ -1,0 +1,3 @@
+SRRtest1
+SRRtest2
+SRRtest3

--- a/src/toil_scripts/adam_pipeline/spark_toil_script.py
+++ b/src/toil_scripts/adam_pipeline/spark_toil_script.py
@@ -67,7 +67,9 @@ def call_conductor(masterIP, inputs, src, dst):
     """
     Invokes the conductor container.
     """
-    docker_call(no_rm = True,work_dir = os.getcwd(), tool = "quay.io/ucsc_cgl/conductor",
+    docker_call(no_rm = True,
+                work_dir = os.getcwd(),
+                tool = "quay.io/ucsc_cgl/conductor",
                 docker_parameters = ["--net=host",
                                      "-e", "AWS_ACCESS_KEY="+inputs['accessKey'],
                                      "-e", "AWS_SECRET_KEY="+inputs['secretKey']],
@@ -80,7 +82,9 @@ def call_conductor(masterIP, inputs, src, dst):
 
 def call_adam(inputs, masterIP, arguments):
 
-    docker_call(no_rm = True,work_dir = os.getcwd(), tool = "quay.io/ucsc_cgl/adam:cd6ef41", 
+    docker_call(no_rm = True,
+                work_dir = os.getcwd(),
+                tool = "quay.io/ucsc_cgl/adam:cd6ef41", 
                 docker_parameter = ["--net=host"],
                 tool_parameters = ["--master", "spark://"+masterIP+":"+SPARK_MASTER_PORT, 
                  "--conf", "spark.driver.memory=%s" % inputs["driverMemory"],
@@ -242,7 +246,9 @@ class MasterService(Job.Service):
         else:
             self.IP = check_output(["hostname", "-f",])[:-1]
 
-        self.sparkContainerID = docker_call(no_rm = True,work_dir = os.getcwd(), tool = "quay.io/ucsc_cgl/apache-spark-master:1.5.2",
+        self.sparkContainerID = docker_call(no_rm = True,
+                                            work_dir = os.getcwd(),
+                                            tool = "quay.io/ucsc_cgl/apache-spark-master:1.5.2",
                                             docker_parameters = ["--net=host",
                                                                  "-d",
                                                                  "-v", "/mnt/ephemeral/:/ephemeral/:rw",
@@ -252,7 +258,9 @@ class MasterService(Job.Service):
                                             tool_parameters = [],
                                             sudo = self.sudo,
                                             check_output = True)[:-1]
-        self.hdfsContainerID = docker_call(no_rm = True,work_dir = os.getcwd(), tool = "quay.io/ucsc_cgl/apache-hadoop-master:2.6.2",
+        self.hdfsContainerID = docker_call(no_rm = True,
+                                           work_dir = os.getcwd(),
+                                           tool = "quay.io/ucsc_cgl/apache-hadoop-master:2.6.2",
                                            docker_parameters = ["--net=host",
                                                                 "-d"],
                                            tool_parameters = [self.IP],
@@ -294,7 +302,9 @@ class WorkerService(Job.Service):
         log.write("start workers\n")
         log.flush()
 
-        self.sparkContainerID = docker_call(no_rm = True,work_dir = os.getcwd(), tool = "quay.io/ucsc_cgl/apache-spark-worker:1.5.2",
+        self.sparkContainerID = docker_call(no_rm = True,
+                                            work_dir = os.getcwd(),
+                                            tool = "quay.io/ucsc_cgl/apache-spark-worker:1.5.2",
                                             docker_parameters = ["--net=host", 
                                                                  "-d",
                                                                  "-v", "/mnt/ephemeral/:/ephemeral/:rw",
@@ -304,7 +314,9 @@ class WorkerService(Job.Service):
                                             tool_parameters = [self.masterIP+":"+SPARK_MASTER_PORT],
                                             sudo = inputs['sudo'],
                                             check_output = True)[:-1]
-        self.hdfsContainerID = docker_call(no_rm = True,work_dir = os.getcwd(), tool = "quay.io/ucsc_cgl/apache-hadoop-worker:2.6.2",
+        self.hdfsContainerID = docker_call(no_rm = True,
+                                           work_dir = os.getcwd(),
+                                           tool = "quay.io/ucsc_cgl/apache-hadoop-worker:2.6.2",
                                            docker_parameters = ["--net=host",
                                                                 "-d",
                                                                 "-v", "/mnt/ephemeral/:/ephemeral/:rw"],

--- a/src/toil_scripts/adam_pipeline/spark_toil_script.py
+++ b/src/toil_scripts/adam_pipeline/spark_toil_script.py
@@ -90,12 +90,6 @@ def call_adam(masterIP, inputs, arguments):
                       "--conf", ("spark.executor.memory=%sg" % inputs["executorMemory"]),
                       "--conf", ("spark.hadoop.fs.default.name=hdfs://%s:%s" % (masterIP, HDFS_MASTER_PORT)),
                       "--"]
-    try:
-        params = default_params + arguments
-    except:
-        log.error("parms: %s" % str(default_params))
-        log.error("args: %s" % str(arguments))
-        raise
 
     docker_call(no_rm = True,
                 work_dir = os.getcwd(),

--- a/src/toil_scripts/adam_pipeline/spark_toil_script.py
+++ b/src/toil_scripts/adam_pipeline/spark_toil_script.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python2.7
 """
 UCSC Computational Genomics Lab RNA-seq Pipeline
@@ -35,6 +34,7 @@ import os
 from subprocess import call, check_call, check_output
 import sys
 from toil.job import Job
+from toil_scripts.batch_alignment.bwa_alignment import docker_call
 
 SPARK_MASTER_PORT = "7077"
 HDFS_MASTER_PORT = "8020"
@@ -48,7 +48,7 @@ def start_master(job, inputs):
     """
     log.write("master job\n")
     log.flush()
-    masterIP = job.addService(MasterService())
+    masterIP = job.addService(MasterService(inputs['sudo']))
     job.addChildJobFn(start_workers, masterIP, inputs)
 
 
@@ -59,7 +59,7 @@ def start_workers(job, masterIP, inputs):
     log.write("workers job\n")
     log.flush()
     for i in range(inputs['numWorkers']):
-        job.addService(WorkerService(masterIP))
+        job.addService(WorkerService(masterIP, inputs['sudo']))
     job.addFollowOnJobFn(download_data, masterIP, inputs)
 
 
@@ -67,16 +67,27 @@ def call_conductor(masterIP, inputs, src, dst):
     """
     Invokes the conductor container.
     """
-    check_call(["docker",
-                "run",
-                "--net=host",
-                "-e", "AWS_ACCESS_KEY="+inputs['accessKey'],
-                "-e", "AWS_SECRET_KEY="+inputs['secretKey'],
-                "quay.io/ucsc_cgl/conductor",
-                "--master", "spark://"+masterIP+":"+SPARK_MASTER_PORT,
-                "--conf", "spark.driver.memory=%s" % inputs["driverMemory"],
-                "--conf", "spark.executor.memory=%s" % inputs["executorMemory"],
-                "--", "-C", src, dst])
+    docker_call(no_rm = True,work_dir = os.getcwd(), tool = "quay.io/ucsc_cgl/conductor",
+                docker_parameters = ["--net=host",
+                                     "-e", "AWS_ACCESS_KEY="+inputs['accessKey'],
+                                     "-e", "AWS_SECRET_KEY="+inputs['secretKey']],
+                tool_parameters = ["--master", "spark://"+masterIP+":"+SPARK_MASTER_PORT,
+                 "--conf", "spark.driver.memory=%s" % inputs["driverMemory"],
+                 "--conf", "spark.executor.memory=%s" % inputs["executorMemory"],
+                 "--", "-C", src, dst],
+                sudo = inputs['sudo'])
+
+
+def call_adam(inputs, masterIP, arguments):
+
+    docker_call(no_rm = True,work_dir = os.getcwd(), tool = "quay.io/ucsc_cgl/adam:cd6ef41", 
+                docker_parameter = ["--net=host"],
+                tool_parameters = ["--master", "spark://"+masterIP+":"+SPARK_MASTER_PORT, 
+                 "--conf", "spark.driver.memory=%s" % inputs["driverMemory"],
+                 "--conf", "spark.executor.memory=%s" % inputs["executorMemory"],
+                 "--conf", "spark.hadoop.fs.default.name=hdfs://%s:%s" % (masterIP, HDFS_MASTER_PORT),
+                 "--"] + arguments,
+                sudo = inputs['sudo'])
 
 
 def remove_file(masterIP, filename):
@@ -120,29 +131,21 @@ def adam_convert(job, masterIP, inFile, snpFile, inputs):
 
     adamFile = ".".join(os.path.splitext(inFile)[:-1])+".adam"
     
-    check_call(["docker", "run", "--net=host",
-                "quay.io/ucsc_cgl/adam:cd6ef41", 
-                "--master", "spark://"+masterIP+":"+SPARK_MASTER_PORT, 
-                "--conf", "spark.driver.memory=%s" % inputs["driverMemory"],
-                "--conf", "spark.executor.memory=%s" % inputs["executorMemory"],
-                "--conf", "spark.hadoop.fs.default.name=hdfs://%s:%s" % (masterIP, HDFS_MASTER_PORT),
-                "--", "transform", 
-                inFile, adamFile])
-    
+    call_adam(masterIP,
+              inputs,
+              ["transform", 
+               inFile, adamFile])
+              
     inFileName = inFile.split("/")[-1]
     remove_file(masterIP, inFileName)
 
     adamSnpFile = ".".join(os.path.splitext(snpFile)[:-1])+".var.adam"
 
-    check_call(["docker", "run", "--net=host",
-                "quay.io/ucsc_cgl/adam:cd6ef41", 
-                "--master", "spark://"+masterIP+":"+SPARK_MASTER_PORT, 
-                "--conf", "spark.driver.memory=%s" % inputs["driverMemory"],
-                "--conf", "spark.executor.memory=%s" % inputs["executorMemory"],
-                "--conf", "spark.hadoop.fs.default.name=hdfs://%s:%s" % (masterIP, HDFS_MASTER_PORT),
-                "--", "vcf2adam", 
-                "-only_variants", 
-                snpFile, adamSnpFile])
+    call_adam(masterIP,
+              inputs,
+              ["vcf2adam", 
+               "-only_variants", 
+               snpFile, adamSnpFile])
 
     snpFileName = snpFile.split("/")[-1]
     remove_file(masterIP, snpFileName)
@@ -162,58 +165,42 @@ def adam_transform(job, masterIP, inFile, snpFile, inputs):
 
     outFile = ".".join(os.path.splitext(inFile)[:-1])+".processed.bam"
 
-    check_call(["docker", "run", "--net=host",
-                "quay.io/ucsc_cgl/adam:cd6ef41", 
-                "--master", "spark://"+masterIP+":"+SPARK_MASTER_PORT, 
-                "--conf", "spark.driver.memory=%s" % inputs["driverMemory"],
-                "--conf", "spark.executor.memory=%s" % inputs["executorMemory"],
-                "--conf", "spark.hadoop.fs.default.name=hdfs://%s:%s" % (masterIP, HDFS_MASTER_PORT),
-                "--", "transform", 
-                inFile,  "hdfs://%s:%s/mkdups.adam" % (masterIP, HDFS_MASTER_PORT),
-                "-aligned_read_predicate",
-                "-limit_projection",
-                "-mark_duplicate_reads"])
+    call_adam(masterIP,
+              inputs,
+              ["transform", 
+               inFile,  "hdfs://%s:%s/mkdups.adam" % (masterIP, HDFS_MASTER_PORT),
+               "-aligned_read_predicate",
+               "-limit_projection",
+               "-mark_duplicate_reads"])
 
     inFileName = inFile.split("/")[-1]
     remove_file(masterIP, inFileName+"*")
 
-    check_call(["docker", "run", "--net=host",
-                "quay.io/ucsc_cgl/adam:cd6ef41", 
-                "--master", "spark://"+masterIP+":"+SPARK_MASTER_PORT, 
-                "--conf", "spark.driver.memory=%s" % inputs["driverMemory"],
-                "--conf", "spark.executor.memory=%s" % inputs["executorMemory"],
-                "--conf", "spark.hadoop.fs.default.name=hdfs://%s:%s" % (masterIP, HDFS_MASTER_PORT),
-                "--", "transform", 
-                "hdfs://%s:%s/mkdups.adam" % (masterIP, HDFS_MASTER_PORT),
-                "hdfs://%s:%s/ri.adam" % (masterIP, HDFS_MASTER_PORT),
-                "-realign_indels"])
+    call_adam(masterIP,
+              inputs,
+              ["transform", 
+               "hdfs://%s:%s/mkdups.adam" % (masterIP, HDFS_MASTER_PORT),
+               "hdfs://%s:%s/ri.adam" % (masterIP, HDFS_MASTER_PORT),
+               "-realign_indels"])
 
     remove_file(masterIP, "mkdups.adam*")
 
-    check_call(["docker", "run", "--net=host",
-                "quay.io/ucsc_cgl/adam:cd6ef41", 
-                "--master", "spark://"+masterIP+":"+SPARK_MASTER_PORT, 
-                "--conf", "spark.driver.memory=%s" % inputs["driverMemory"],
-                "--conf", "spark.executor.memory=%s" % inputs["executorMemory"],
-                "--conf", "spark.hadoop.fs.default.name=hdfs://%s:%s" % (masterIP, HDFS_MASTER_PORT),
-                "--", "transform", 
-                "hdfs://%s:%s/ri.adam" % (masterIP, HDFS_MASTER_PORT),
-                "hdfs://%s:%s/bqsr.adam" % (masterIP, HDFS_MASTER_PORT),
-                "-recalibrate_base_qualities", 
-                "-known_snps", snpFile])
-    
+    call_adam(masterIP,
+              inputs,
+              ["transform", 
+               "hdfs://%s:%s/ri.adam" % (masterIP, HDFS_MASTER_PORT),
+               "hdfs://%s:%s/bqsr.adam" % (masterIP, HDFS_MASTER_PORT),
+               "-recalibrate_base_qualities", 
+               "-known_snps", snpFile])
+              
     remove_file(masterIP, "ri.adam*")
 
-    check_call(["docker", "run", "--net=host",
-                "quay.io/ucsc_cgl/adam:cd6ef41", 
-                "--master", "spark://"+masterIP+":"+SPARK_MASTER_PORT, 
-                "--conf", "spark.driver.memory=%s" % inputs["driverMemory"],
-                "--conf", "spark.executor.memory=%s" % inputs["executorMemory"],
-                "--conf", "spark.hadoop.fs.default.name=hdfs://%s:%s" % (masterIP, HDFS_MASTER_PORT),
-                "--", "transform", 
-                "hdfs://%s:%s/bqsr.adam" % (masterIP, HDFS_MASTER_PORT), 
-                outFile,
-                "-sort_reads", "-single"])
+    call_adam(masterIP,
+              inputs,
+              ["transform", 
+               "hdfs://%s:%s/bqsr.adam" % (masterIP, HDFS_MASTER_PORT), 
+               outFile,
+               "-sort_reads", "-single"])
 
     remove_file(masterIP, "bqsr.adam*")
 
@@ -236,6 +223,12 @@ def upload_data(job, masterIP, hdfsName, inputs):
 
 class MasterService(Job.Service):
 
+    def __init__(self, sudo):
+
+        Job.Service.__init__(self)
+        self.sudo = sudo
+
+
     def start(self):
         """
         Start spark and hdfs master containers
@@ -249,20 +242,22 @@ class MasterService(Job.Service):
         else:
             self.IP = check_output(["hostname", "-f",])[:-1]
 
-        self.sparkContainerID = check_output(["docker",
-                                              "run",
-                                              "--net=host",
-                                              "-d",
-                                              "-v", "/mnt/ephemeral/:/ephemeral/:rw",
-                                              "-e", "SPARK_MASTER_IP="+self.IP,
-                                              "-e", "SPARK_LOCAL_DIRS=/ephemeral/spark/local",
-                                              "-e", "SPARK_WORKER_DIR=/ephemeral/spark/work",
-                                              "quay.io/ucsc_cgl/apache-spark-master:1.5.2"])[:-1]
-        self.hdfsContainerID = check_output(["docker",
-                                             "run",
-                                             "--net=host",
-                                             "-d",
-                                             "quay.io/ucsc_cgl/apache-hadoop-master:2.6.2", self.IP])[:-1]
+        self.sparkContainerID = docker_call(no_rm = True,work_dir = os.getcwd(), tool = "quay.io/ucsc_cgl/apache-spark-master:1.5.2",
+                                            docker_parameters = ["--net=host",
+                                                                 "-d",
+                                                                 "-v", "/mnt/ephemeral/:/ephemeral/:rw",
+                                                                 "-e", "SPARK_MASTER_IP="+self.IP,
+                                                                 "-e", "SPARK_LOCAL_DIRS=/ephemeral/spark/local",
+                                                                 "-e", "SPARK_WORKER_DIR=/ephemeral/spark/work"],
+                                            tool_parameters = [],
+                                            sudo = self.sudo,
+                                            check_output = True)[:-1]
+        self.hdfsContainerID = docker_call(no_rm = True,work_dir = os.getcwd(), tool = "quay.io/ucsc_cgl/apache-hadoop-master:2.6.2",
+                                           docker_parameters = ["--net=host",
+                                                                "-d"],
+                                           tool_parameters = [self.IP],
+                                           sudo = self.sudo,
+                                           check_output = True)[:-1]
         return self.IP
 
     def stop(self):
@@ -271,20 +266,26 @@ class MasterService(Job.Service):
         """
         log.write("stop masters\n")
         log.flush()
-        call(["docker", "exec", self.sparkContainerID, "rm", "-r", "/ephemeral/spark"])
-        call(["docker", "stop", self.sparkContainerID])
-        call(["docker", "rm", self.sparkContainerID])
-        call(["docker", "stop", self.hdfsContainerID])
-        call(["docker", "rm", self.hdfsContainerID])
+        
+        sudo = []
+        if self.sudo:
+            sudo = ["sudo"]
+
+        call(sudo + ["docker", "exec", self.sparkContainerID, "rm", "-r", "/ephemeral/spark"])
+        call(sudo + ["docker", "stop", self.sparkContainerID])
+        call(sudo + ["docker", "rm", self.sparkContainerID])
+        call(sudo + ["docker", "stop", self.hdfsContainerID])
+        call(sudo + ["docker", "rm", self.hdfsContainerID])
 
         return
 
                 
 class WorkerService(Job.Service):
     
-    def __init__(self, masterIP):
+    def __init__(self, masterIP, sudo):
         Job.Service.__init__(self)
         self.masterIP = masterIP
+        self.sudo = sudo
 
     def start(self):
         """
@@ -293,22 +294,24 @@ class WorkerService(Job.Service):
         log.write("start workers\n")
         log.flush()
 
-        self.sparkContainerID = check_output(["docker",
-                                              "run",
-                                              "--net=host", 
-                                              "-d",
-                                              "-v", "/mnt/ephemeral/:/ephemeral/:rw",
-                                              "-e", "\"SPARK_MASTER_IP="+self.masterIP+":"+SPARK_MASTER_PORT+"\"",
-                                              "-e", "SPARK_LOCAL_DIRS=/ephemeral/spark/local",
-                                              "-e", "SPARK_WORKER_DIR=/ephemeral/spark/work",
-                                              "quay.io/ucsc_cgl/apache-spark-worker:1.5.2", 
-                                              self.masterIP+":"+SPARK_MASTER_PORT])[:-1]
-        self.hdfsContainerID = check_output(["docker",
-                                             "run",
-                                             "--net=host",
-                                             "-d",
-                                             "-v", "/mnt/ephemeral/:/ephemeral/:rw",
-                                             "quay.io/ucsc_cgl/apache-hadoop-worker:2.6.2", self.masterIP])[:-1]
+        self.sparkContainerID = docker_call(no_rm = True,work_dir = os.getcwd(), tool = "quay.io/ucsc_cgl/apache-spark-worker:1.5.2",
+                                            docker_parameters = ["--net=host", 
+                                                                 "-d",
+                                                                 "-v", "/mnt/ephemeral/:/ephemeral/:rw",
+                                                                 "-e", "\"SPARK_MASTER_IP="+self.masterIP+":"+SPARK_MASTER_PORT+"\"",
+                                                                 "-e", "SPARK_LOCAL_DIRS=/ephemeral/spark/local",
+                                                                 "-e", "SPARK_WORKER_DIR=/ephemeral/spark/work"],
+                                            tool_parameters = [self.masterIP+":"+SPARK_MASTER_PORT],
+                                            sudo = inputs['sudo'],
+                                            check_output = True)[:-1]
+        self.hdfsContainerID = docker_call(no_rm = True,work_dir = os.getcwd(), tool = "quay.io/ucsc_cgl/apache-hadoop-worker:2.6.2",
+                                           docker_parameters = ["--net=host",
+                                                                "-d",
+                                                                "-v", "/mnt/ephemeral/:/ephemeral/:rw"],
+                                           tool_parameters = [self.masterIP],
+                                           sudo = inputs['sudo'],
+                                           check_output = True)[:-1]
+                                           
         return
 
     def stop(self):
@@ -318,12 +321,16 @@ class WorkerService(Job.Service):
         log.write("stop workers\n")
         log.flush()
 
-        call(["docker", "exec", self.sparkContainerID, "rm", "-r", "/ephemeral/spark"])
-        call(["docker", "stop", self.sparkContainerID])
-        call(["docker", "rm", self.sparkContainerID])
-        call(["docker", "exec", self.hdfsContainerID, "rm", "-r", "/ephemeral/hdfs"])
-        call(["docker", "stop", self.hdfsContainerID])
-        call(["docker", "rm", self.hdfsContainerID])
+        sudo = []
+        if self.sudo:
+            sudo = ['sudo']
+
+        call(sudo + ["docker", "exec", self.sparkContainerID, "rm", "-r", "/ephemeral/spark"])
+        call(sudo + ["docker", "stop", self.sparkContainerID])
+        call(sudo + ["docker", "rm", self.sparkContainerID])
+        call(sudo + ["docker", "exec", self.hdfsContainerID, "rm", "-r", "/ephemeral/hdfs"])
+        call(sudo + ["docker", "stop", self.hdfsContainerID])
+        call(sudo + ["docker", "rm", self.hdfsContainerID])
 
         return
 
@@ -348,6 +355,12 @@ def build_parser():
                         help = 'Amount of memory to allocate for Spark Driver.')
     parser.add_argument('-q', '--executor_memory', required = True,
                         help = 'Amount of memory to allocate per Spark Executor.')
+    parser.add_argument('-u', '--sudo',
+                        dest='sudo', action='store_true',
+                        help='Docker usually needs sudo to execute '
+                        'locally, but not''when running Mesos '
+                        'or when a member of a Docker group.')
+
     return parser
 
 
@@ -364,7 +377,8 @@ def main(args):
               'accessKey':  options.aws_access_key,
               'secretKey':  options.aws_secret_key,
               'driverMemory': options.driver_memory,
-              'executorMemory': options.executor_memory}
+              'executorMemory': options.executor_memory,
+              'sudo': options.sudo}
 
     Job.Runner.startToil(Job.wrapJobFn(start_master, inputs), options)
 

--- a/src/toil_scripts/batch_alignment/bwa_alignment.py
+++ b/src/toil_scripts/batch_alignment/bwa_alignment.py
@@ -197,6 +197,8 @@ def docker_call(work_dir,
 
     base_docker_call = ('docker run %s --log-driver=none -v %s:/data' % (rm, work_dir)).split()
 
+    log.warn("Calling docker with %s." % " ".join(base_docker_call))
+
     if sudo:
         base_docker_call = ['sudo'] + base_docker_call
     if java_opts:
@@ -534,13 +536,8 @@ def upload_to_s3(work_dir, input_args, output_file):
     job_vars: tuple         Contains the dictionaries: input_args and ids
     """
 
-    # Parse s3_dir to get bucket and s3 path
-    s3_dir = input_args['s3_dir']
-    bucket_name = s3_dir.lstrip('/').split('/')[0]
-    bucket_dir = '/'.join(s3_dir.lstrip('/').split('/')[1:])
-    base_url = 'https://s3.amazonaws.com/'
-    url = os.path.join(base_url, bucket_name, bucket_dir, output_file)
-    
+    work_dir = job.fileStore.getLocalTempDir()
+
     if input_args['aws_access_key']:
         os.environ['AWS_ACCESS_KEY_ID'] = input_args['aws_access_key']
     if input_args['aws_secret_key']:
@@ -601,6 +598,7 @@ def main():
     parser = build_parser()
     Job.Runner.addToilOptions(parser)
     args = parser.parse_args()
+
     # Store input parameters in a dictionary
     inputs = {'config': args.config,
               'ref.fa': args.ref,

--- a/src/toil_scripts/batch_alignment/bwa_alignment.py
+++ b/src/toil_scripts/batch_alignment/bwa_alignment.py
@@ -32,11 +32,16 @@ from collections import OrderedDict
 import hashlib
 import multiprocessing
 import os
+import sys
 import errno
 import subprocess
 import shutil
 import tarfile
+import logging
 from toil.job import Job
+
+
+log = logging.getLogger(__name__)
 
 
 def build_parser():
@@ -59,6 +64,7 @@ def build_parser():
     parser.add_argument('-3', '--s3_dir', default=None, help='S3 Directory, starting with bucket name. e.g.: '
                                                              'cgl-driver-projects/ckcc/rna-seq-samples/')
     parser.add_argument('-k', '--use_bwakit', action='store_true', help='Use bwakit instead of the binary build of bwa')
+    parser.add_argument('-se', '--file_size', default='100G', help='Approximate input file size. Should be given as %d[TGMK], e.g., for a 100 gigabyte file, use --file_size 100G')
     parser.set_defaults(sudo=False)
     return parser
 
@@ -134,7 +140,10 @@ def download_from_url(job, url):
     file_path = os.path.join(work_dir, os.path.basename(url))
     if not os.path.exists(file_path):
         try:
-            subprocess.check_call(['curl', '-fs', '--retry', '5', '--create-dir', url, '-o', file_path])
+            download_cmd = ['curl', '-fs', '--retry', '5', '--create-dir', url, '-o', file_path]
+            log.info("Downloading file using command %s." % " ".join(download_cmd))
+            sys.stderr.write( "Downloading file using command %s.\n" % " ".join(download_cmd))
+            subprocess.check_call(download_cmd)
         except OSError:
             raise RuntimeError('Failed to find "curl". Install via "apt-get install curl"')
     assert os.path.exists(file_path)
@@ -164,7 +173,15 @@ def return_input_paths(job, work_dir, ids, *args):
     return paths.values()
 
 
-def docker_call(work_dir, tool_parameters, tool, java_opts=None, outfile=None, sudo=False):
+def docker_call(work_dir,
+                tool_parameters,
+                tool,
+                java_opts=None,
+                outfile=None,
+                sudo=False,
+                docker_parameters=None,
+                check_output=False,
+                no_rm=False):
     """
     Makes subprocess call of a command to a docker container.
 
@@ -174,16 +191,31 @@ def docker_call(work_dir, tool_parameters, tool, java_opts=None, outfile=None, s
     outfile: file           Filehandle that stderr will be passed to
     sudo: bool              If the user wants the docker command executed as sudo
     """
-    base_docker_call = 'docker run --rm --log-driver=none -v {}:/data'.format(work_dir).split()
+    rm = '--rm'
+    if no_rm:
+        rm = ''
+
+    base_docker_call = ('docker run %s --log-driver=none -v %s:/data' % (rm, work_dir)).split()
+
     if sudo:
         base_docker_call = ['sudo'] + base_docker_call
     if java_opts:
         base_docker_call = base_docker_call + ['-e', 'JAVA_OPTS={}'.format(java_opts)]
+    if docker_parameters:
+        base_docker_call = base_docker_call + docker_parameters
+
+    log.warn("Calling docker with %s." % " ".join(base_docker_call))
+    sys.stderr.write( "Calling docker with %s\n" % " ".join(base_docker_call))
+
     try:
         if outfile:
             subprocess.check_call(base_docker_call + [tool] + tool_parameters, stdout=outfile)
         else:
-            subprocess.check_call(base_docker_call + [tool] + tool_parameters)
+            if check_output:
+                return subprocess.check_output(base_docker_call + [tool] + tool_parameters)
+            else:
+                subprocess.check_call(base_docker_call + [tool] + tool_parameters)
+
     except subprocess.CalledProcessError:
         raise RuntimeError('docker command returned a non-zero exit status. Check error logs.')
     except OSError:
@@ -252,6 +284,15 @@ def parse_config(job, shared_ids, input_args):
     """
     samples = []
     config = input_args['config']
+
+    # does the config file exist locally? if not, try to read from job store
+    if not os.path.exists(config):
+
+        work_dir = job.fileStore.getLocalTempDir()
+        config_path = os.path.join(work_dir, 'config.txt')
+        job.fileStore.readGlobalFile(config, config_path)
+        config = config_path
+
     with open(config, 'r') as f_in:
         for line in f_in:
             line = line.strip().split(',')
@@ -261,7 +302,7 @@ def parse_config(job, shared_ids, input_args):
     input_args['cpu_count'] = multiprocessing.cpu_count()
     job_vars = (input_args, shared_ids)
     for sample in samples:
-        job.addChildJobFn(download_inputs, job_vars, sample, cores=input_args['cpu_count'], memory='20 G', disk='100 G')
+        job.addChildJobFn(download_inputs, job_vars, sample, cores=input_args['cpu_count'], memory='20 G', disk=input_args['file_size'])
 
 
 def download_inputs(job, job_vars, sample):
@@ -277,9 +318,9 @@ def download_inputs(job, job_vars, sample):
     for i in xrange(2):
         if input_args['ssec']:
             key_path = input_args['ssec']
-            ids['r{}.fq.gz'.format(i+1)] = job.addChildJobFn(download_encrypted_file, urls[i], key_path, disk='100G').rv()
+            ids['r{}.fq.gz'.format(i+1)] = job.addChildJobFn(download_encrypted_file, urls[i], key_path, disk=input_args['file_size']).rv()
         else:
-            ids['r{}.fq.gz'.format(i+1)] = job.addChildJobFn(download_from_url, urls[i], disk='100G').rv()
+            ids['r{}.fq.gz'.format(i+1)] = job.addChildJobFn(download_from_url, urls[i], disk=input_args['file_size']).rv()
     job.addFollowOnJobFn(static_dag_declaration, job_vars)
 
 
@@ -296,9 +337,9 @@ def static_dag_declaration(job, job_vars):
     # if we run with bwakit, we skip conversion
     if input_args['use_bwakit']:
 
-        bwa = job.wrapJobFn(run_bwa, job_vars, cores=cores, disk='150G')
-        header = job.wrapJobFn(fix_bam_header, job_vars, bwa.rv(), disk='100G')
-        rg = job.wrapJobFn(add_readgroups, job_vars, header.rv(), memory='15G', disk='100G')
+        bwa = job.wrapJobFn(run_bwa, job_vars, cores=cores, disk=input_args['file_size'])
+        header = job.wrapJobFn(fix_bam_header, job_vars, bwa.rv(), disk=input_args['file_size'])
+        rg = job.wrapJobFn(add_readgroups, job_vars, header.rv(), memory='15G', disk=input_args['file_size'])
         
         # Link
         job.addChild(bwa)
@@ -307,10 +348,10 @@ def static_dag_declaration(job, job_vars):
     
     else:
 
-        bwa = job.wrapJobFn(run_bwa, job_vars, cores=cores, disk='150G')
-        conversion = job.wrapJobFn(bam_conversion, job_vars, bwa.rv(), disk='150G')
-        header = job.wrapJobFn(fix_bam_header, job_vars, conversion.rv(), disk='100G')
-        rg = job.wrapJobFn(add_readgroups, job_vars, header.rv(), memory='15G', disk='100G')
+        bwa = job.wrapJobFn(run_bwa, job_vars, cores=cores, disk=input_args['file_size'])
+        conversion = job.wrapJobFn(bam_conversion, job_vars, bwa.rv(), disk=input_args['file_size'])
+        header = job.wrapJobFn(fix_bam_header, job_vars, conversion.rv(), disk=input_args['file_size'])
+        rg = job.wrapJobFn(add_readgroups, job_vars, header.rv(), memory='15G', disk=input_args['file_size'])
         
         # Link
         job.addChild(bwa)
@@ -348,8 +389,16 @@ def run_bwa(job, job_vars):
                       '/data/r1.fq.gz',
                       '/data/r2.fq.gz']
 
-        docker_call(tool='quay.io/ucsc_cgl/bwakit:0.7.12',
-                    tool_parameters=parameters, work_dir=work_dir, sudo=sudo)
+        try:
+            docker_call(tool='quay.io/ucsc_cgl/bwakit:0.7.12',
+                        tool_parameters=parameters, work_dir=work_dir, sudo=sudo)
+        except:
+            last = work_dir.split('/')[-1]
+            log.warn("Copying files from %s to /mnt/ephemeral/frank/%s" % (work_dir, last))
+            sys.stderr.write("Copying files from %s to /mnt/ephemeral/frank/%s\n" % (work_dir, last))
+
+            shutil.copytree(work_dir, "/mnt/ephemeral/frank/%s" % last)
+            raise
 
         # bwa insists on adding an `*.aln.sam` suffix, so rename the output file
         os.rename(os.path.join(work_dir, 'aligned.aln.bam'),
@@ -448,6 +497,7 @@ def add_readgroups(job, job_vars, bam_id):
     output_file = '{}.bam'.format(uuid)
     # Retrieve input file
     job.fileStore.readGlobalFile(bam_id, os.path.join(work_dir, 'aligned_fixpg.bam'))
+    sys.stderr.write("Read global file to %s, adding read groups and saving to %s." % (os.path.join(work_dir, 'aligned_fixpg.bam'), os.path.join(work_dir, output_file)))
     # Call: Samtools
     parameters = ['AddOrReplaceReadGroups',
                   'I=/data/aligned_fixpg.bam',
@@ -460,45 +510,81 @@ def add_readgroups(job, job_vars, bam_id):
                   'SM={}'.format(uuid)]
     docker_call(tool='quay.io/ucsc_cgl/picardtools:1.95--dd5ac549b95eb3e5d166a5e310417ef13651994e',
                 tool_parameters=parameters, work_dir=work_dir, java_opts='-Xmx15G', sudo=sudo)
-    ids['out_bam'] = job.fileStore.writeGlobalFile(os.path.join(work_dir, output_file))
+
     # Either write file to local output directory or upload to S3 cloud storage
     if input_args['output_dir']:
         copy_to_output_dir(work_dir=work_dir, output_dir=input_args['output_dir'], files=[output_file])
     if input_args['s3_dir']:
-        job.addChildJobFn(upload_to_s3, job_vars, disk='80G')
+        try:
+            upload_to_s3(work_dir, input_args, output_file)
+        except:
+            last = work_dir.split('/')[-1]
+            log.warn("Copying files from %s to /mnt/ephemeral/frank/%s" % (work_dir, last))
+            sys.stderr.write("Copying files from %s to /mnt/ephemeral/frank/%s\n" % (work_dir, last))
+        
+            shutil.copytree(work_dir, "/mnt/ephemeral/frank/%s" % last)
+            raise
 
 
-def upload_to_s3(job, job_vars):
+def upload_to_s3(work_dir, input_args, output_file):
     """
     Uploads a file to S3 via S3AM with encryption.  This pipeline assumes all
     BAMS contain patient data and must be encrypted upon upload.
 
     job_vars: tuple         Contains the dictionaries: input_args and ids
     """
-    # Unpack variables
-    input_args, ids = job_vars
-    uuid = input_args['uuid']
-    key_path = input_args['ssec']
-    work_dir = job.fileStore.getLocalTempDir()
+
     # Parse s3_dir to get bucket and s3 path
     s3_dir = input_args['s3_dir']
     bucket_name = s3_dir.lstrip('/').split('/')[0]
     bucket_dir = '/'.join(s3_dir.lstrip('/').split('/')[1:])
-    base_url = 'https://s3-us-west-2.amazonaws.com/'
-    url = os.path.join(base_url, bucket_name, bucket_dir, uuid + '.bam')
-    # Retrieve file to be uploaded
-    job.fileStore.readGlobalFile(ids['out_bam'], os.path.join(work_dir, uuid + '.bam'))
-    # Generate keyfile for upload
-    with open(os.path.join(work_dir, uuid + '.key'), 'wb') as f_out:
-        f_out.write(generate_unique_key(key_path, url))
-    # Upload to S3 via S3AM
-    s3am_command = ['s3am',
-                    'upload',
-                    '--sse-key-file', os.path.join(work_dir, uuid + '.key'),
-                    'file://{}'.format(os.path.join(work_dir, uuid + '.bam')),
-                    os.path.join('s3://', bucket_name, bucket_dir, uuid + '.bam')]
-    subprocess.check_call(s3am_command)
+    base_url = 'https://s3.amazonaws.com/'
+    url = os.path.join(base_url, bucket_name, bucket_dir, output_file)
+    
+    if input_args['aws_access_key']:
+        os.environ['AWS_ACCESS_KEY_ID'] = input_args['aws_access_key']
+    if input_args['aws_secret_key']:
+        os.environ['AWS_SECRET_ACCESS_KEY'] = input_args['aws_secret_key']
 
+    # what is the path we are uploading to?
+    s3_path = os.path.join('s3://', bucket_name, bucket_dir, output_file)
+
+    # does this need to be uploaded with encryption?
+    if input_args['ssec']:
+       key_path = input_args['ssec']
+
+       # Generate keyfile for upload
+       with open(os.path.join(work_dir, uuid + '.key'), 'wb') as f_out:
+           f_out.write(generate_unique_key(key_path, url))
+
+       # Upload to S3 via S3AM
+       s3am_command = ['s3am',
+                       'upload',
+                       '--sse-key-file', os.path.join(work_dir, uuid + '.key'),
+                       'file://{}'.format(os.path.join(work_dir, output_file)),
+                       s3_path]
+
+    else:
+        # Upload to S3 via S3AM
+        s3am_command = ['s3am',
+                        'upload',
+                        'file://{}'.format(os.path.join(work_dir, output_file)),
+                        s3_path]
+
+    # run upload
+    log.info("Calling s3am with %s" % " ".join(s3am_command))
+    try:
+        subprocess.check_call(s3am_command)
+    except:
+        log.error("Upload to %s failed. Cancelling..." % s3_path)
+        s3am_cancel = ['s3am', 'cancel', s3_path]
+        
+        try:
+            subprocess.check_call(s3am_cancel)
+        except:
+            log.error("Cancelling upload with '%s' failed." % " ".join(s3am_cancel))
+
+        raise
 
 def main():
     """
@@ -532,7 +618,10 @@ def main():
               'lb': args.lb,
               'uuid': None,
               'cpu_count': None,
-              'use_bwakit': args.use_bwakit}
+              'file_size': args.file_size,
+              'use_bwakit': args.use_bwakit,
+              'aws_access_key': None,
+              'aws_secret_key': None}
 
     # Launch Pipeline
     Job.Runner.startToil(Job.wrapJobFn(download_shared_files, inputs), args)


### PR DESCRIPTION
Don't expect this to work yet. Will ping @almussel @jvivian @hannes-ucsc @heuermh and @benedictpaten offline with more details.

This builds off of #72. The big thing I wanted to get out there was the package refactoring. I made toil-scripts itself a package, and then changed a bunch of file names to conform with PEP8 (specifically, no underscores in package/module names). That is done in two commits: 86d45cba557680f6198e95ab1507b55dd8f2678a for packaging and 8714903c93e05bcbc534e3638cad58ac294ccaaa for underscores in file names.