### PR TITLE
Added alt-aware alignment for GRCh38 reference build to alignment pipeline

### DIFF
--- a/src/toil_scripts/batch_alignment/launch_bwakit_grch38.sh
+++ b/src/toil_scripts/batch_alignment/launch_bwakit_grch38.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Frank Austin Nothaft, fnothaft@berkeley.edu
+#
+# Pipeline for alt-aware alignment against the GRCh38 build used in the 1000G vs. b38 recompute.
+# Precautionary step: Create location where jobStore and tmp files will exist and set TOIL_HOME.
+TOIL_HOME=FIXME
+mkdir -p ${TOIL_HOME}/toil_mnt
+# Execution of pipeline
+python -m toil_scripts.batch_alignment.bwa_alignment \
+${TOIL_HOME}/toil_mnt/jobStore \
+--retryCount 3 \
+--config bwa_config.csv \
+--lb LIB \
+--ref https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa \
+--amb https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.amb \
+--ann https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.ann \
+--bwt https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.bwt \
+--pac https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.pac \
+--sa https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.sa \
+--fai https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.fai \
+--alt https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.alt \
+--use_bwakit \
+--workDir ${TOIL_HOME}/toil_mnt \
+--output_dir ${TOIL_HOME} \
+--s3_dir cgl-driver-projects/test/alignment \
+--sudo


### PR DESCRIPTION
Aligns reads to GRCh38/alts using [bwakit](https://github.com/lh3/bwa/tree/master/bwakit), which builds in bwa-postalts, which [lifts alt alignments](https://github.com/lh3/bwa/blob/master/README-alt.md) back to the non-alt contigs and is necessary for finalizing alt aware read alignments.

Supercedes #86. Depends on [cgl-docker-lib#76](https://github.com/BD2KGenomics/cgl-docker-lib/pull/76).