### PR TITLE
Select between GRCh38 and HG19

### DIFF
--- a/src/toil_scripts/adam_uberscript/adam_uberscript.py
+++ b/src/toil_scripts/adam_uberscript/adam_uberscript.py
@@ -125,28 +125,29 @@ def launch_pipeline(params):
                                '-o', 'StrictHostKeyChecking=no',
                                'screen', '-dmS', params.cluster_name])
 
+        # Run command on screen session  
 
-        # do we have a defined master ip?
-        masterIP_arg = ""
-        if params.master_ip:
-            masterIP_arg = "--master_ip %s" % params.master_ip
+        if params.reference_genome == 'GRCh38':
+            from toil_scripts.adam_uberscript.input_files import GRCh38_inputs as inputs
+        elif params.reference_genome == 'hg19':
+            from toil_scripts.adam_uberscript.input_files import hg19_inputs as inputs
+        else:
+            raise Exception("Invalid reference genome, reference should have been  validated as a choice during argument parsing.  Should not have reached this point, arg parsing code likely out of date.")
 
-        # Run command on screen session        
-        pipeline_command = ("PYTHONPATH=$PYTHONPATH:~/toil-scripts/src python -m toil_scripts.adam_gatk_pipeline.align_and_call " +
-                            "aws:{region}:{j} " +
-                            "--autoscale_cluster " +
-                            "--sequence_dir {sequence_dir} " +
-                            "--retryCount 1 " +
-                            "--s3_bucket {b} " +
-                            "--bucket_region {region} " +
-                            "--uuid_manifest ~/manifest " +
-                            "--ref {ref} " +
-                            "--amb {amb} " +
-                            "--ann {ann} " +
-                            "--bwt {bwt} " +
-                            "--pac {pac} " +
-                            "--sa {sa} " +
-                            "--fai {fai} " ) 
+        pipeline_command = "PYTHONPATH=$PYTHONPATH:~/toil-scripts/src python -m toil_scripts.adam_gatk_pipeline.align_and_call " + \
+                           "aws:{region}:{j} " + \
+                           "--autoscale_cluster " + \
+                           "--retryCount 1 " + \
+                           "--s3_bucket {b} " + \
+                           "--bucket_region {region} " + \
+                           "--uuid_manifest ~/manifest " + \
+                           "--ref {ref} " + \
+                           "--amb {amb} " + \
+                           "--ann {ann} " + \
+                           "--bwt {bwt} " + \
+                           "--pac {pac} " + \
+                           "--sa {sa} " + \
+                           "--fai {fai} "
         if 'alt' in inputs:
           pipeline_command +=   pipeline_command += "--alt {alt} "
         pipeline_command += "--use_bwakit " +

--- a/src/toil_scripts/adam_uberscript/adam_uberscript.py
+++ b/src/toil_scripts/adam_uberscript/adam_uberscript.py
@@ -37,7 +37,6 @@ import boto.sdb
 from boto.ec2 import connect_to_region
 
 from automated_scaling import ClusterSize, Samples
-from toil_scripts.adam_uberscript.input_files import inputs
 
 metric_endtime_margin = timedelta(hours=1)
 metric_initial_wait_period_in_seconds = 0
@@ -126,6 +125,7 @@ def launch_pipeline(params):
                                '-o', 'StrictHostKeyChecking=no',
                                'screen', '-dmS', params.cluster_name])
 
+
         # do we have a defined master ip?
         masterIP_arg = ""
         if params.master_ip:
@@ -146,9 +146,10 @@ def launch_pipeline(params):
                             "--bwt {bwt} " +
                             "--pac {pac} " +
                             "--sa {sa} " +
-                            "--fai {fai} " +
-                            "--alt {alt} " +
-                            "--use_bwakit " +
+                            "--fai {fai} " ) 
+        if 'alt' in inputs:
+          pipeline_command +=   pipeline_command += "--alt {alt} "
+        pipeline_command += "--use_bwakit " +
                             "--num_nodes {s} " +
                             "--driver_memory {m} " +
                             "--executor_memory {m} " +
@@ -464,9 +465,12 @@ def main():
     parser_pipeline.add_argument('-m', '--memory', default='200g', help='The memory per worker node in GB') 
     parser_pipeline.add_argument('-f', '--file_size', default='100G', help='Approximate size of the BAM files')
     parser_pipeline.add_argument('-s', '--spark_nodes', default='9', help='The number of nodes needed for the spark cluster')
+
     parser_pipeline.add_argument('-SD', '--sequence_dir',
                                  help = 'Directory where raw sequences are.',
                                  default = 'sequence')
+
+    parser_pipeline.add_argument('-R', '--reference_genome', required=True, choices=['GRCh38','hg19'], help='Reference Genome to align and call against.  Choose between GRCh38 and hg19')
 
     # Launch Metric Collection
     parser_metric = subparsers.add_parser('launch-metrics', help='Launches metric collection thread')

--- a/src/toil_scripts/adam_uberscript/input_files.py
+++ b/src/toil_scripts/adam_uberscript/input_files.py
@@ -1,5 +1,5 @@
 
-inputs = {    "ref": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa",
+GRCh38_inputs = {    "ref": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa",
               "amb": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.amb",
               "ann": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.ann",
               "bwt": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.bwt",
@@ -12,3 +12,19 @@ inputs = {    "ref": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/var
             "dbsnp": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/ALL_20141222.dbSNP142_human_GRCh38.snps.vcf",
              "omni": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/1000G_omni2.5.grch38.reordered.vcf",
            "hapmap": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/hapmap_3.3.grch38.reordered.vcf"}
+
+hg19_inputs = {    "ref": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hg19.fa",
+              "amb": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hg19.fa.amb",
+              "ann": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hg19.fa.ann",
+              "bwt": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hg19.fa.bwt",
+              "pac": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hg19.fa.pac",
+               "sa": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hg19.fa.sa",
+              "fai": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hg19.fa.fai",
+            "phase": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/1000G_phase1.indels.hg19.sites.vcf",
+            "mills": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hapmap_3.3.hg19.sites.vcf",
+            "dbsnp": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/dbsnp_138.hg19.vcf",
+             "omni": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/1000G_omni2.5.hg19.sites.vcf",
+           "hapmap": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hapmap_3.3.hg19.sites.vcf"}
+           
+
+

--- a/src/toil_scripts/adam_uberscript/input_files.py
+++ b/src/toil_scripts/adam_uberscript/input_files.py
@@ -1,30 +1,30 @@
 
 GRCh38_inputs = {    "ref": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa",
-              "amb": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.amb",
-              "ann": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.ann",
-              "bwt": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.bwt",
-              "pac": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.pac",
-               "sa": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.sa",
-              "fai": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.fai",
-              "alt": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.alt",
-            "phase": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/1000G_phase1.snps.high_confidence.grch38.reordered.vcf",
-            "mills": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/Mills_and_1000G_gold_standard.indels.grch38.reordered.vcf",
-            "dbsnp": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/ALL_20141222.dbSNP142_human_GRCh38.snps.vcf",
-             "omni": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/1000G_omni2.5.grch38.reordered.vcf",
-           "hapmap": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/hapmap_3.3.grch38.reordered.vcf"}
+                     "amb": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.amb",
+                     "ann": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.ann",
+                     "bwt": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.bwt",
+                     "pac": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.pac",
+                      "sa": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.sa",
+                     "fai": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.fai",
+                     "alt": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/GRCh38_full_analysis_set_plus_decoy_hla.reordered.fa.alt",
+                   "phase": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/1000G_phase1.snps.high_confidence.grch38.reordered.vcf",
+                   "mills": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/Mills_and_1000G_gold_standard.indels.grch38.reordered.vcf",
+                   "dbsnp": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/ALL_20141222.dbSNP142_human_GRCh38.snps.vcf",
+                    "omni": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/1000G_omni2.5.grch38.reordered.vcf",
+                  "hapmap": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38_reordered/hapmap_3.3.grch38.reordered.vcf"}
 
 hg19_inputs = {    "ref": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hg19.fa",
-              "amb": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hg19.fa.amb",
-              "ann": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hg19.fa.ann",
-              "bwt": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hg19.fa.bwt",
-              "pac": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hg19.fa.pac",
-               "sa": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hg19.fa.sa",
-              "fai": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hg19.fa.fai",
-            "phase": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/1000G_phase1.indels.hg19.sites.vcf",
-            "mills": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hapmap_3.3.hg19.sites.vcf",
-            "dbsnp": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/dbsnp_138.hg19.vcf",
-             "omni": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/1000G_omni2.5.hg19.sites.vcf",
-           "hapmap": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hapmap_3.3.hg19.sites.vcf"}
+                   "amb": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hg19.fa.amb",
+                   "ann": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hg19.fa.ann",
+                   "bwt": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hg19.fa.bwt",
+                   "pac": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hg19.fa.pac",
+                    "sa": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hg19.fa.sa",
+                   "fai": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hg19.fa.fai",
+                 "phase": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/1000G_phase1.indels.hg19.sites.vcf",
+                 "mills": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hapmap_3.3.hg19.sites.vcf",
+                 "dbsnp": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/dbsnp_138.hg19.vcf",
+                  "omni": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/1000G_omni2.5.hg19.sites.vcf",
+                "hapmap": "https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_hg19_reordered/hapmap_3.3.hg19.sites.vcf"}
            
 
 


### PR DESCRIPTION
Allows selection between `GRCh38` and `hg19` using the `--reference-genome` parameter
as discussed in #132

This code has only been tested for parameter parsing, it has not yet been run on a cluster, let me know if you want me to test it further before this PR is accepted 