### PR TITLE
Auto-scaling of standalone Spark cluster (resolves #152)

### DIFF
--- a/src/toil_scripts/adam_pipeline/adam_preprocessing.py
+++ b/src/toil_scripts/adam_pipeline/adam_preprocessing.py
@@ -24,37 +24,76 @@ Toil pipeline for ADAM preprocessing
 ================================================================================
 :Dependencies
 docker          - apt-get install docker (or 'docker.io' for linux)
-toil            - pip install --pre toil
+toil            - pip install toil
 """
 
-# python core libraries
 import argparse
 import logging
 import multiprocessing
 import os
-from subprocess import call, check_call, check_output
+from subprocess import check_call, check_output
 import sys
-import time
 
-# toil imports
 from toil.job import Job
 
-# toil scripts imports
+from toil_scripts.adam_uberscript.automated_scaling import SparkMasterAddress
 from toil_scripts.batch_alignment.bwa_alignment import docker_call
-from toil_scripts.spark_utils.spawn_cluster import *
+from toil_scripts.spark_utils.spawn_cluster import start_spark_hdfs_cluster
 
 SPARK_MASTER_PORT = "7077"
 HDFS_MASTER_PORT = "8020"
 log = logging.getLogger(__name__)
 
+
+class MasterAddress(str):
+    """
+    A string containing the hostname or IP of the Spark/HDFS master. The Spark master expects its own address to
+    match what the client uses to connect to it. For example, if the master is configured with a host name,
+    the driver can't use an IP address to connect to it, and vice versa. This class works around by distinguishing
+    between the notional master address (self) and the actual one (self.actual) and adds support for the special
+    master address "auto" in order to implement auto-discovery of the master of a standalone.
+
+    >>> foo = MasterAddress('foo')
+    >>> foo == 'foo'
+    True
+    >>> foo.actual == 'foo'
+    True
+    >>> foo.actual == foo
+    True
+    """
+    def __init__(self, master_ip):
+        # TBD: this could do more tricks like always mapping an IP address to 'spark-master' etc.
+        if master_ip == 'auto':
+            super(MasterAddress, self).__init__('spark-master')
+            self.actual = SparkMasterAddress.load_in_toil().value
+        else:
+            super(MasterAddress, self).__init__(master_ip)
+            self.actual = self
+
+    def docker_parameters(self, docker_parameters=None):
+        """
+        Augment a list of "docker run" arguments with those needed to map the notional Spark master address to the
+        real one, if they are different.
+        """
+        if self != self.actual:
+            add_host_option = '--add-host=spark-master:' + self.actual
+            if docker_parameters is None:
+                docker_parameters = [add_host_option]
+            else:
+                docker_parameters.append(add_host_option)
+        return docker_parameters
+
+
 def call_conductor(masterIP, inputs, src, dst):
     """
-    Invokes the conductor container.
+    Invokes the Conductor container to copy files between S3 and HDFS
+
+    :type masterIP: MasterAddress
     """
     docker_call(no_rm = True,
                 work_dir = os.getcwd(),
                 tool = "quay.io/ucsc_cgl/conductor",
-                docker_parameters = ["--net=host"],
+                docker_parameters = masterIP.docker_parameters(["--net=host"]),
                 tool_parameters = ["--master", "spark://"+masterIP+":"+SPARK_MASTER_PORT,
                  "--conf", "spark.driver.memory=%sg" % inputs["driverMemory"],
                  "--conf", "spark.executor.memory=%sg" % inputs["executorMemory"],
@@ -63,17 +102,20 @@ def call_conductor(masterIP, inputs, src, dst):
 
 
 def call_adam(masterIP, inputs, arguments):
+    """
+    Invokes the ADAM container
 
-    default_params = ["--master", ("spark://%s:%s" % (masterIP, SPARK_MASTER_PORT)), 
+    :type masterIP: MasterAddress
+    """
+    default_params = ["--master", ("spark://%s:%s" % (masterIP, SPARK_MASTER_PORT)),
                       "--conf", ("spark.driver.memory=%sg" % inputs["driverMemory"]),
                       "--conf", ("spark.executor.memory=%sg" % inputs["executorMemory"]),
                       "--conf", ("spark.hadoop.fs.default.name=hdfs://%s:%s" % (masterIP, HDFS_MASTER_PORT)),
                       "--"]
-
     docker_call(no_rm = True,
                 work_dir = os.getcwd(),
                 tool = "quay.io/ucsc_cgl/adam:962-ehf--6e7085f8cac4b9a927dc9fb06b48007957256b80",
-                docker_parameters = ["--net=host"],
+                docker_parameters = masterIP.docker_parameters(["--net=host"]),
                 tool_parameters = default_params + arguments,
                 sudo = inputs['sudo'])
 
@@ -81,7 +123,10 @@ def call_adam(masterIP, inputs, arguments):
 def remove_file(masterIP, filename, sparkOnToil):
     """
     Remove the given file from hdfs with master at the given IP address
+
+    :type masterIP: MasterAddress
     """
+    masterIP = masterIP.actual
     if sparkOnToil:
         try:
             containerID = check_output(["ssh", "-o", "StrictHostKeyChecking=no", masterIP, "docker", "ps", \
@@ -93,12 +138,14 @@ def remove_file(masterIP, filename, sparkOnToil):
     else:
         log.warning("Cannot remove file %s. Can only remove files when running Spark-on-Toil", filename)
 
+# FIXME: unused parameter sparkOnToil
 
 def download_data(masterIP, inputs, sparkOnToil):
     """
-    Downloads input data files from s3.
-    """
+    Downloads input data files from S3.
 
+    :type masterIP: MasterAddress
+    """
     snpFileSystem, snpPath = inputs['knownSNPs'].split('://')
     snpName = snpPath.split('/')[-1]
     log.info("SNPS at %s:%s:%s", masterIP, HDFS_MASTER_PORT, snpName)
@@ -106,14 +153,14 @@ def download_data(masterIP, inputs, sparkOnToil):
     
     log.info("Downloading known sites file %s to %s.", inputs['knownSNPs'], hdfsSNPs)
     call_conductor(masterIP, inputs, inputs['knownSNPs'], hdfsSNPs)
-        
+
     bamFileSystem, bamPath = inputs['bamName'].split('://')
     bamName = bamPath.split('/')[-1]
     hdfsBAM = "hdfs://"+masterIP+":"+HDFS_MASTER_PORT+"/"+bamName
 
     log.info("Downloading input BAM %s to %s.", inputs['bamName'], hdfsBAM)
     call_conductor(masterIP, inputs, inputs['bamName'], hdfsBAM)
-     
+
     return (hdfsBAM, hdfsSNPs)
 
 
@@ -124,12 +171,12 @@ def adam_convert(masterIP, inFile, snpFile, inputs, sparkOnToil):
 
     log.info("Converting input BAM to ADAM.")
     adamFile = ".".join(os.path.splitext(inFile)[:-1])+".adam"
-    
+
     call_adam(masterIP,
               inputs,
-              ["transform", 
+              ["transform",
                inFile, adamFile])
-              
+
     inFileName = inFile.split("/")[-1]
     remove_file(masterIP, inFileName, sparkOnToil)
 
@@ -138,13 +185,13 @@ def adam_convert(masterIP, inFile, snpFile, inputs, sparkOnToil):
 
     call_adam(masterIP,
               inputs,
-              ["vcf2adam", 
-               "-only_variants", 
+              ["vcf2adam",
+               "-only_variants",
                snpFile, adamSnpFile])
 
     snpFileName = snpFile.split("/")[-1]
     remove_file(masterIP, snpFileName, sparkOnToil)
- 
+
     return (adamFile, adamSnpFile)
 
 def adam_transform(masterIP, inFile, snpFile, inputs, sparkOnToil):
@@ -160,7 +207,7 @@ def adam_transform(masterIP, inFile, snpFile, inputs, sparkOnToil):
     log.info("Marking duplicate reads.")
     call_adam(masterIP,
               inputs,
-              ["transform", 
+              ["transform",
                inFile,  "hdfs://%s:%s/mkdups.adam" % (masterIP, HDFS_MASTER_PORT),
                "-aligned_read_predicate",
                "-limit_projection",
@@ -172,7 +219,7 @@ def adam_transform(masterIP, inFile, snpFile, inputs, sparkOnToil):
     log.info("Realigning INDELs.")
     call_adam(masterIP,
               inputs,
-              ["transform", 
+              ["transform",
                "hdfs://%s:%s/mkdups.adam" % (masterIP, HDFS_MASTER_PORT),
                "hdfs://%s:%s/ri.adam" % (masterIP, HDFS_MASTER_PORT),
                "-realign_indels"])
@@ -182,19 +229,19 @@ def adam_transform(masterIP, inFile, snpFile, inputs, sparkOnToil):
     log.info("Recalibrating base quality scores.")
     call_adam(masterIP,
               inputs,
-              ["transform", 
+              ["transform",
                "hdfs://%s:%s/ri.adam" % (masterIP, HDFS_MASTER_PORT),
                "hdfs://%s:%s/bqsr.adam" % (masterIP, HDFS_MASTER_PORT),
-               "-recalibrate_base_qualities", 
+               "-recalibrate_base_qualities",
                "-known_snps", snpFile])
-              
+
     remove_file(masterIP, "ri.adam*", sparkOnToil)
 
     log.info("Sorting reads and saving a single BAM file.")
     call_adam(masterIP,
               inputs,
-              ["transform", 
-               "hdfs://%s:%s/bqsr.adam" % (masterIP, HDFS_MASTER_PORT), 
+              ["transform",
+               "hdfs://%s:%s/bqsr.adam" % (masterIP, HDFS_MASTER_PORT),
                outFile,
                "-sort_reads", "-single"])
 
@@ -210,7 +257,7 @@ def upload_data(masterIP, hdfsName, inputs, sparkOnToil):
 
     fileSystem, path = hdfsName.split('://')
     nameOnly = path.split('/')[-1]
-    
+
     uploadName = "%s/%s" % (inputs['outDir'], nameOnly.replace('.processed', ''))
     if inputs['suffix']:
         uploadName = uploadName.replace('.bam', '%s.bam' % inputs['suffix'])
@@ -219,13 +266,12 @@ def upload_data(masterIP, hdfsName, inputs, sparkOnToil):
     call_conductor(masterIP, inputs, hdfsName, uploadName)
 
 
-# toil jobs
-
 def download_run_and_upload(job, masterIP, inputs, sparkOnToil):
     """
     Monolithic job that calls data download, conversion, transform, upload.
     Previously, this was not monolithic; change came in due to #126/#134.
     """
+    masterIP = MasterAddress(masterIP)
     try:
         bam, snps = download_data(masterIP, inputs, sparkOnToil)
         adamInput, adamSnps = adam_convert(masterIP, bam, snps, inputs, sparkOnToil)
@@ -240,16 +286,16 @@ def download_run_and_upload(job, masterIP, inputs, sparkOnToil):
 
         raise
 
+
 def static_adam_preprocessing_dag(job, inputs):
-
+    """
+    A Toil job function performing ADAM preprocessing on a single sample
+    """
     masterIP = inputs['masterIP']
-    followJob = job
-    sparkOnToil = not masterIP
-
-    cores = multiprocessing.cpu_count()
-
-    # if the master IP string was not passed in, then we need to start a spark cluster
-    if sparkOnToil:
+    if not masterIP:
+        # Dynamic subclusters, i.e. Spark-on-Toil
+        sparkOnToil = True
+        cores = multiprocessing.cpu_count()
         startCluster = job.wrapJobFn(start_spark_hdfs_cluster,
                                      inputs['numWorkers'],
                                      inputs['executorMemory'],
@@ -259,11 +305,31 @@ def static_adam_preprocessing_dag(job, inputs):
                                      jCores = cores,
                                      jMemory = "%s G" % inputs['driverMemory']).encapsulate()
         job.addChild(startCluster)
-
+    elif masterIP == 'auto':
+        # Static, standalone Spark cluster managed by uberscript
+        sparkOnToil = False
+        scaleUp = job.wrapJobFn(scale_external_spark_cluster, 1)
+        job.addChild(scaleUp)
+        sparkWork = job.wrapJobFn(download_run_and_upload, masterIP, inputs, sparkOnToil)
+        scaleUp.addChild(sparkWork)
+        scaleDown = job.wrapJobFn(scale_external_spark_cluster, -1)
+        sparkWork.addChild(scaleDown)
     else:
-        # otherwise, should run first
+        # Static, external Spark cluster
+        sparkOnToil = False
         sparkWork = job.wrapJobFn(download_run_and_upload, masterIP, inputs, sparkOnToil)
         job.addChild(sparkWork)
+
+
+def scale_external_spark_cluster(num_samples=1):
+    from toil_scripts.adam_uberscript.adam_uberscript import standalone_spark_semaphore_name
+    from toil_scripts.adam_uberscript.automated_scaling import Semaphore
+    sem = Semaphore.load_in_toil(standalone_spark_semaphore_name)
+    if num_samples > 0:
+        sem.acquire(delta=num_samples)
+    else:
+        sem.release(delta=-num_samples)
+
 
 def build_parser():
 
@@ -285,7 +351,10 @@ def build_parser():
     parser.add_argument('-j', '--jobstore', required = True,
                         help = 'Name of the jobstore')
     parser.add_argument('-m', '--master_ip', required = False, default = None,
-                        help = 'IP for the Spark master/HDFS Namenode, if not spawning a cluster.')
+                        help="IP or hostname of host running for Spark master and HDFS namenode. Should be provided "
+                             "if pointing at a static (external or standalone) Spark cluster. The special value "
+                             "'auto' indicates the master of standalone cluster, i.e. one that is managed by the "
+                             "uberscript.")
     parser.add_argument('-u', '--sudo',
                         dest='sudo', action='store_true',
                         help='Docker usually needs sudo to execute '
@@ -294,16 +363,16 @@ def build_parser():
 
     return parser
 
+# FIXME: unused parameter args
 
 def main(args):
-    
+
     parser = build_parser()
     Job.Runner.addToilOptions(parser)
     options = parser.parse_args()
 
-    if not ((options.master_ip and not options.num_nodes) or
-            (not options.master_ip and options.num_nodes)):
-        raise ValueError("Only one of --master_ip (%s) and --num_nodes (%d) can be provided." % 
+    if bool(options.master_ip) != bool(options.num_nodes):
+        raise ValueError("Only one of --master_ip (%s) and --num_nodes (%d) can be provided." %
                          (options.master_ip, options.num_nodes))
 
     if options.num_nodes <= 1:
@@ -320,7 +389,8 @@ def main(args):
               'suffix': None,
               'masterIP': options.master_ip}
 
-    Job.Runner.startToil(Job.wrapJobFn(start_master, inputs), options)
+    Job.Runner.startToil(Job.wrapJobFn(static_adam_preprocessing_dag, inputs), options)
 
 if __name__=="__main__":
+    # FIXME: main() doesn't return anything
     sys.exit(main(sys.argv[1:]))

--- a/src/toil_scripts/adam_pipeline/adam_preprocessing.py
+++ b/src/toil_scripts/adam_pipeline/adam_preprocessing.py
@@ -129,14 +129,19 @@ def remove_file(masterIP, filename, sparkOnToil):
     masterIP = masterIP.actual
     if sparkOnToil:
         try:
-            containerID = check_output(["ssh", "-o", "StrictHostKeyChecking=no", masterIP, "docker", "ps", \
-                                        "|", "grep", "apache-hadoop-master", "|", "awk", "'{print $1}'"])[:-1]
-            check_call(["ssh", "-o", "StrictHostKeyChecking=no", masterIP, "docker", "exec", containerID, \
-                        "/opt/apache-hadoop/bin/hdfs", "dfs", "-rm", "-r", "/"+filename])
+            output = check_output(['ssh',
+                                   '-o', 'StrictHostKeyChecking=no',
+                                   masterIP, 'docker', 'ps'])
+            containerID = next(line.split()[0] for line in output.splitlines() if 'apache-hadoop-master' in line)
+            check_call(['ssh',
+                        '-o', 'StrictHostKeyChecking=no',
+                        masterIP,
+                        'docker', 'exec', containerID,
+                        'hdfs', 'dfs', '-rm', '-r', '/' + filename])
         except:
             pass
     else:
-        log.warning("Cannot remove file %s. Can only remove files when running Spark-on-Toil", filename)
+        log.warning('Cannot remove file %s. Can only remove files when running Spark-on-Toil', filename)
 
 # FIXME: unused parameter sparkOnToil
 

--- a/src/toil_scripts/adam_uberscript/adam_uberscript.py
+++ b/src/toil_scripts/adam_uberscript/adam_uberscript.py
@@ -4,6 +4,8 @@
 # basicConfig.
 
 import logging
+from contextlib import contextmanager
+from subprocess import check_call, CalledProcessError, check_output
 
 log = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO,
@@ -13,7 +15,7 @@ logging.basicConfig(level=logging.INFO,
 import argparse
 import csv
 import errno
-import subprocess
+import os
 import threading
 import time
 from StringIO import StringIO
@@ -25,8 +27,7 @@ from uuid import uuid4
 import boto
 import boto.ec2.cloudwatch
 import boto.sdb
-import os
-from automated_scaling import ClusterSize, Samples
+from automated_scaling import ClusterSize, Samples, Semaphore, SparkMasterAddress
 from boto.ec2 import connect_to_region
 from boto.exception import BotoServerError, EC2ResponseError
 from boto_lib import get_instance_ids
@@ -40,7 +41,9 @@ metric_start_time_margin = 1800
 scaling_initial_wait_period_in_seconds = 300
 cluster_scaling_interval_in_seconds = 300
 
-cluster_size_lock = threading.Lock()
+# Protects against concurrent changes to the size of the Toil cluster, by both the metric thread terminating idle
+# nodes and the cluster-growing thread adding nodes.
+cluster_size_lock = threading.RLock()
 
 aws_region = 'us-west-2'
 
@@ -53,49 +56,44 @@ def launch_cluster(params):
     """
     log.info('Launching cluster of size: {} and type: {}'.format(1, params.instance_type))
 
-    # if user provides a string to add to /etc/hosts, let's pass that through
-    etc = []
-    if params.add_to_etc_hosts:
-        etc = ['-O', 'etc_hosts_entries=%s' % params.add_to_etc_hosts]
-
-    subprocess.check_call(['cgcloud',
-                           'create-cluster',
-                           '--zone', aws_region + 'a',
-                           '--cluster-name', params.cluster_name,
-                           '--leader-instance-type', params.leader_type,
-                           '--instance-type', params.instance_type,
-                           '--num-workers', '1',
-                           '--ssh-opts',
-                           '"StrictHostKeyChecking=no"'] +
-                          etc +
-                          ['toil'])
-    subprocess.check_call(['cgcloud',
-                           'rsync',
-                           '--zone', aws_region + 'a',
-                           '--cluster-name', params.cluster_name,
-                           '--ssh-opts="-o StrictHostKeyChecking=no"',
-                           'toil-leader',
-                           '-a',
-                           params.manifest_path, ':~/manifest'])
-    subprocess.check_call(['cgcloud',
-                           'rsync',
-                           '--zone', aws_region + 'a',
-                           '--cluster-name', params.cluster_name,
-                           '--ssh-opts="-o StrictHostKeyChecking=no"',
-                           'toil-leader',
-                           '-a',
-                           params.share.rstrip('/'), ':'])
+    check_call(['cgcloud',
+                'create-cluster',
+                '--zone', aws_region + 'a',
+                '--cluster-name', params.cluster_name,
+                '--leader-instance-type', params.leader_type,
+                '--instance-type', params.instance_type,
+                '--num-workers', '1',
+                '--ssh-opts',
+                '"StrictHostKeyChecking=no"'] +
+               role_options(params) +
+               ['toil'])
+    check_call(['cgcloud',
+                'rsync',
+                '--zone', aws_region + 'a',
+                '--cluster-name', params.cluster_name,
+                '--ssh-opts="-o StrictHostKeyChecking=no"',
+                'toil-leader',
+                '-a',
+                params.manifest_path, ':~/manifest'])
+    check_call(['cgcloud',
+                'rsync',
+                '--zone', aws_region + 'a',
+                '--cluster-name', params.cluster_name,
+                '--ssh-opts="-o StrictHostKeyChecking=no"',
+                'toil-leader',
+                '-a',
+                params.share.rstrip('/'), ':'])
 
 
 def place_boto_on_leader(params):
     log.info('Adding a .boto to leader to avoid credential timeouts.')
-    subprocess.check_call(['cgcloud',
-                           'rsync',
-                           '--zone', aws_region + 'a',
-                           '--cluster-name', params.cluster_name,
-                           '--ssh-opts="-o StrictHostKeyChecking=no"',
-                           'toil-leader',
-                           params.boto_path, ':~/.boto'])
+    check_call(['cgcloud',
+                'rsync',
+                '--zone', aws_region + 'a',
+                '--cluster-name', params.cluster_name,
+                '--ssh-opts="-o StrictHostKeyChecking=no"',
+                'toil-leader',
+                params.boto_path, ':~/.boto'])
 
 
 def launch_pipeline(params):
@@ -112,13 +110,13 @@ def launch_pipeline(params):
     log.info('Launching Pipeline and blocking. Check log.txt on leader for stderr and stdout')
     try:
         # Create screen session
-        subprocess.check_call(['cgcloud',
-                               'ssh',
-                               '--zone', aws_region + 'a',
-                               '--cluster-name', params.cluster_name,
-                               'toil-leader',
-                               '-o', 'StrictHostKeyChecking=no',
-                               'screen', '-dmS', params.cluster_name])
+        check_call(['cgcloud',
+                    'ssh',
+                    '--zone', aws_region + 'a',
+                    '--cluster-name', params.cluster_name,
+                    'toil-leader',
+                    '-o', 'StrictHostKeyChecking=no',
+                    'screen', '-dmS', params.cluster_name])
 
         if params.reference_genome == 'GRCh38':
             from toil_scripts.adam_uberscript.input_files import GRCh38_inputs as inputs
@@ -182,16 +180,16 @@ def launch_pipeline(params):
 
         chunk_size = 500
         for chunk in [pipeline_command[i:i + chunk_size] for i in range(0, len(pipeline_command), chunk_size)]:
-            subprocess.check_call(['cgcloud',
-                                   'ssh',
-                                   '--zone', aws_region + 'a',
-                                   '--cluster-name', params.cluster_name,
-                                   'toil-leader',
-                                   '-o', 'StrictHostKeyChecking=no',
-                                   'screen', '-S', params.cluster_name,
-                                   '-X', 'stuff', quote(chunk)])
+            check_call(['cgcloud',
+                        'ssh',
+                        '--zone', aws_region + 'a',
+                        '--cluster-name', params.cluster_name,
+                        'toil-leader',
+                        '-o', 'StrictHostKeyChecking=no',
+                        'screen', '-S', params.cluster_name,
+                        '-X', 'stuff', quote(chunk)])
 
-    except subprocess.CalledProcessError as e:
+    except CalledProcessError as e:
         log.info('Pipeline exited with non-zero status code: {}'.format(e))
 
 
@@ -220,110 +218,179 @@ def get_cluster_size(cluster_name):
     """
     Returns the number of running toil-worker nodes
     """
-    return len(list_workers(cluster_name))
+    return len(list_nodes(cluster_name))
 
 
-def list_workers(cluster_name):
+def list_nodes(cluster_name, role='toil-worker'):
     """
     Returns list of dictionaries, each dictionary representing a worker node. Each dictinoary has the following keys:
     cluster_name, role_name, ordinal, cluster_ordinal, private_ip_address, ip_address, instance_id, instance_type,
     launch_time, state and zone
     """
-    return parse_cgcloud_list_output(subprocess.check_output(['cgcloud', 'list', '-c', cluster_name, 'toil-worker']))
+    return parse_cgcloud_list_output(check_output(['cgcloud', 'list', '-c', cluster_name, role]))
 
 
 def parse_cgcloud_list_output(output):
     return [row for row in csv.DictReader(StringIO(output), delimiter='\t')]
 
 
-def get_desired_cluster_size(conn, dom):
-    nodes_per_sample = Samples.load(conn, dom)
+def get_desired_cluster_size(domain):
+    nodes_per_sample = Samples.load(domain)
     return sum(map(lambda x: x[1], nodes_per_sample.samples.values()))
 
 
-def update_cluster_size(conn, dom, n):
-    ClusterSize.change_size(conn, dom, n)
-
-
-def grow_cluster(nodes, instance_type, cluster_name, etc):
+def update_cluster_size(domain, n):
     """
-    Grow the cluster by n nodes
+    Only to be invoked by the uberscript
     """
-    nodes_left = nodes
-    while nodes_left > 0:
-        log.info('Attempting to grow cluster by %i node(s) of type: %s', nodes_left, instance_type)
+    with cluster_size_lock:
+        cluster_size = ClusterSize.load(domain)
+        cluster_size.value = n
+        # Holding the lock should prevent concurrent modifications
+        cluster_size.save()
 
-        output = ''
+
+def grow_cluster(num_nodes, instance_type, cluster_name, cluster_type='toil', *options):
+    """
+    Grow a cluster by a given number of nodes
+    """
+    nodes = []
+    num_nodes_left = num_nodes
+    while num_nodes_left > 0:
+        log.info('Attempting to grow cluster by %i node(s) of type: %s', num_nodes_left, instance_type)
         cmd = (['cgcloud',
                 'grow-cluster',
                 '--list',
                 '--instance-type', instance_type,
-                '--num-workers', str(nodes_left),
+                '--num-workers', str(num_nodes_left),
                 '--cluster-name', cluster_name] +
-               etc +
-               ['toil'])
+               list(options) +
+               [cluster_type])
         try:
-            output = subprocess.check_output(cmd)
-        except subprocess.CalledProcessError as cpe:
-            log.warn('Running command %s returned with error code %d.',
-                     ' '.join(cmd),
-                     cpe.returncode)
-            output = cpe.output
-
-        added_nodes = len(parse_cgcloud_list_output(output))
-        if added_nodes == 0:
+            output = check_output(cmd)
+        except CalledProcessError as e:
+            log.warn('Command %r failed with status code %d.', cmd, e.returncode)
+            output = e.output
+        nodes_added = parse_cgcloud_list_output(output)
+        nodes.extend(nodes_added)
+        num_nodes_added = len(nodes_added)
+        if num_nodes_added == 0:
             log.warn("Wasn't able to add any nodes. Wating 5 min.")
             time.sleep(5 * 60)
-        assert added_nodes <= nodes_left
-        nodes_left -= added_nodes
-        log.info('Added %d node(s), %d node(s) left.', added_nodes, nodes_left)
-    log.info('Successfully grew cluster by %i node(s) of type %s.', nodes, instance_type)
+        assert num_nodes_added <= num_nodes_left
+        num_nodes_left -= num_nodes_added
+        log.info('Added %d node(s), %d node(s) left.', num_nodes_added, num_nodes_left)
+    assert len(nodes) == num_nodes
+    log.info('Successfully grew cluster by %i node(s) of type %s.', num_nodes, instance_type)
+    return nodes
 
 
 def manage_metrics_and_cluster_scaling(params):
     conn = boto.sdb.connect_to_region(aws_region)
     dom = conn.get_domain('{0}--files'.format(params.jobstore))
-    grow_cluster_thread = threading.Thread(target=monitor_cluster_size, args=(params, conn, dom))
-    metric_collection_thread = threading.Thread(target=collect_realtime_metrics, args=(params, conn, dom))
+    grow_cluster_thread = threading.Thread(target=manage_toil_cluster, args=(params, conn, dom))
+    metric_collection_thread = threading.Thread(target=collect_realtime_metrics, args=(params,))
     grow_cluster_thread.start()
     metric_collection_thread.start()
     grow_cluster_thread.join()
     metric_collection_thread.join()
 
 
-def monitor_cluster_size(params, conn, dom):
+def role_options(params):
     """
-    Monitors cluster size and grows it if the desired size is larger than the current size
+    :type params: argparse.Namespace
     """
-
-    # if user provides a string to add to /etc/hosts, let's pass that through
-    etc = []
+    options = []
     if params.add_to_etc_hosts:
-        etc = ['-O', 'etc_hosts_entries=%s' % params.add_to_etc_hosts]
+        options.extend(['-O', 'etc_hosts_entries=%s' % params.add_to_etc_hosts])
+    return options
 
-    log.info('Cluster size monitor has started.')
+
+@contextmanager
+def throttle(interval):
+    """
+    A context manager for ensuring that the execution of its body takes at least a given amount of time, sleeping if
+    necessary.
+    """
+    start = time.time()
+    yield
+    duration = time.time() - start
+    remainder = interval - duration
+    if remainder > 0:
+        time.sleep(remainder)
+
+
+def manage_toil_cluster(params, domain):
+    log.info('Auto-scaling of Toil cluster has started.')
     time.sleep(scaling_initial_wait_period_in_seconds)
     while True:
-        size_check_time = time.time()
-        # If cluster is too small, grow it
-        cluster_size = get_cluster_size(params.cluster_name)
-        desired_cluster_size = get_desired_cluster_size(conn, dom) + 1
-        if cluster_size < desired_cluster_size:
-            with cluster_size_lock:
-                grow_cluster(desired_cluster_size - cluster_size, params.instance_type, params.cluster_name, etc)
-                update_cluster_size(conn, dom, desired_cluster_size)
-
-        # Sleep
-        resize_time = time.time() - size_check_time
-        log.info('Cluster is {} nodes as of {}'.format(get_cluster_size(params.cluster_name), resize_time))
-        wait_time = cluster_scaling_interval_in_seconds - resize_time
-        if wait_time > 0:
-            time.sleep(wait_time)
+        with throttle(cluster_scaling_interval_in_seconds):
+            cluster_size = len(list_nodes(params.cluster_name))
+            desired_cluster_size = get_desired_cluster_size(domain) + 1
+            if cluster_size < desired_cluster_size:
+                with cluster_size_lock:
+                    num_nodes = desired_cluster_size - cluster_size
+                    grow_cluster(num_nodes, params.instance_type, params.cluster_name, *role_options(params))
+                    update_cluster_size(domain, desired_cluster_size)
+            cluster_size = len(list_nodes(params.cluster_name))
+            log.info('Toil cluster is now at %i node(s).', cluster_size)
 
 
-# FIXME: unused parameters conn and dom
+standalone_spark_semaphore_name = 'standalone_spark_sample_slots'
 
-def collect_realtime_metrics(params, conn, dom, threshold=0.5, region='us-west-2'):
+
+def manage_standalone_spark_cluster(params, domain):
+    semaphore = Semaphore.create(domain=domain,
+                                 name=standalone_spark_semaphore_name,
+                                 value=params.spark_sample_slots)
+    while True:
+        with throttle(cluster_scaling_interval_in_seconds):
+            # How many samples are being computed (or waiting to be computed) on the Spark cluster? ...
+            num_unused_sample_slots = semaphore.value
+            num_samples = params.spark_sample_slots - num_unused_sample_slots
+            assert num_samples >= 0
+            if num_samples:
+                # ... At least one sample is. How many Spark workers are needed for all of them.
+                spark_workers_per_sample = params.spark_nodes - 1
+                num_desired_workers = num_samples * spark_workers_per_sample
+                num_workers = len(list_nodes(params.cluster_name, role='spark-slave'))
+                num_masters = len(list_nodes(params.cluster_name, role='spark-master'))
+                if num_masters == 0:
+                    # Absence of master indicates absence of cluster, so create it now.
+                    assert num_workers == 0, 'Orphaned Spark workers detected'
+                    output = check_output(['cgcloud',
+                                           'create-cluster',
+                                           '--list',
+                                           '--zone', aws_region + 'a',
+                                           '--cluster-name', params.cluster_name,
+                                           '--leader-instance-type', params.spark_master_type or params.leader_type,
+                                           '--instance-type', params.spark_instance_type or params.instance_type,
+                                           '--num-workers', str(num_desired_workers),  # TODO: spot options
+                                           '--ssh-opts', '"StrictHostKeyChecking=no"'] +
+                                          role_options(params) +
+                                          ['spark'])
+                    output = parse_cgcloud_list_output(output)
+                    assert len(output) == 1
+                    master = output[0]
+                    assert master['role_name'] == 'spark-master'
+                    SparkMasterAddress.create(domain, master['private_ip_address']).save(force=True)
+                elif num_masters == 1:
+                    # There already is a Spark cluster, so scale it if necessary. 
+                    if num_desired_workers > num_workers:
+                        grow_cluster(num_nodes=num_desired_workers - num_workers,
+                                     instance_type=params.instance_type,
+                                     cluster_name=params.cluster_name,
+                                     cluster_type='spark')
+                    elif num_desired_workers < num_workers:
+                        pass  # TODO: think about scaling down
+                    else:
+                        pass  # Cluster already has desired size
+                else:
+                    assert False, 'Unexpected number of master nodes: %i' % num_masters
+        semaphore = Semaphore.load(domain, name=standalone_spark_semaphore_name)
+
+
+def collect_realtime_metrics(params, threshold=0.5, region='us-west-2'):
     """
     Collect metrics from AWS instances in 1 hour intervals.
     Instances that have gone idle (below threshold CPU value) are terminated.
@@ -353,7 +420,7 @@ def collect_realtime_metrics(params, conn, dom, threshold=0.5, region='us-west-2
     conn = boto.ec2.connect_to_region(region)
     cw = boto.ec2.cloudwatch.connect_to_region(region)
     sdbconn = boto.sdb.connect_to_region(region)
-    dom = sdbconn.get_domain('{0}--files'.format(params.jobstore))
+    domain = sdbconn.get_domain('{0}--files'.format(params.jobstore))
 
     # Create initial variables
     start = datetime.utcfromtimestamp(start)
@@ -401,11 +468,11 @@ def collect_realtime_metrics(params, conn, dom, threshold=0.5, region='us-west-2
                     try:
                         with cluster_size_lock:
                             cluster_size = get_cluster_size(params.cluster_name)
-                            if cluster_size > get_desired_cluster_size(sdbconn, dom):
+                            if cluster_size > get_desired_cluster_size(domain):
                                 log.info('Terminating Instance: {}'.format(instance_id))
                                 log.info('Killing instance {0}\n'.format(instance_id))
                                 conn.terminate_instances(instance_ids=[instance_id])
-                                update_cluster_size(sdbconn, dom, cluster_size - 1)
+                                update_cluster_size(domain, cluster_size - 1)
                     except (EC2ResponseError, BotoServerError) as e:
                         log.info('Error terminating instance: {}\n{}'.format(instance_id, e))
                 # Set start point to be last collected timestamp
@@ -439,14 +506,11 @@ def mkdir_p(path):
 
 
 def main():
-    """
-    Modular script for running toil pipelines
-    """
     parser = argparse.ArgumentParser(description=main.__doc__,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     subparsers = parser.add_subparsers(dest='command')
 
-    # Launch Cluster
+    # Launch cluster
     cluster_sp = subparsers.add_parser('launch-cluster',
                                        help='Launches EC2 cluster via CGCloud')
     cluster_sp.add_argument('-S', '--share', required=True,
@@ -457,7 +521,7 @@ def main():
                             help='Path to local .boto file to be placed on leader.')
     cluster_sp.add_argument('-M', '--manifest-path', required=True, help='Path to manifest file.')
 
-    # Launch Pipeline
+    # Launch pipeline
     pipeline_sp = subparsers.add_parser('launch-pipeline',
                                         help='Launches pipeline')
     pipeline_sp.add_argument('-j', '--jobstore', default=None,
@@ -465,7 +529,9 @@ def main():
     pipeline_sp.add_argument('--restart', default=None, action='store_true',
                              help='Attempts to restart pipeline, requires existing job store.')
     pipeline_sp.add_argument('--master_ip', default=None,
-                             help='Spark Master IP.')
+                             help="The address of an external Spark master or 'auto' when using a standalone Spark "
+                                  "cluster managed by this script. In that latter case you must pass the "
+                                  "--max-samples-on-spark option to the launch-metric command.")
     pipeline_sp.add_argument('-B', '--bucket',
                              help='The name of the destination bucket.')
     pipeline_sp.add_argument('-m', '--memory', default='200g',
@@ -473,23 +539,31 @@ def main():
                                   'the specified worker instance type')
     pipeline_sp.add_argument('-f', '--file_size', default='100G',
                              help='Approximate size of the BAM files')
-    pipeline_sp.add_argument('-s', '--spark_nodes', default='9',
-                             help='The number of nodes needed for each Spark sub-cluster')
+    pipeline_sp.add_argument('-s', '--spark_nodes', type=int, default=8 + 1,
+                             help="The number of Spark nodes, including the master, to allocate per sample. Relevant with separate "
+                                  "running against a standSpark cluster managed, the master will be shared by all samples "
+                                  "and the actual number of workers allocated per sample will be one less than "
+                                  "specified here. Otherwise, each sample's subcluster will get its own master node.")
     pipeline_sp.add_argument('-SD', '--sequence_dir', default='sequence',
                              help='Directory where raw sequences are.')
     pipeline_sp.add_argument('-R', '--reference_genome', required=True,
                              choices=['GRCh38', 'hg19'],
                              help='Reference genome to align and call against. Choose between GRCh38 and hg19.')
 
-    # Launch Metric Collection
+    # Launch metric collection
     metric_sp = subparsers.add_parser('launch-metrics',
                                       help='Launches metric collection thread')
-    metric_sp.add_argument('-j', '--jobstore', required=True,
+    metric_sp.add_argument('-j', '--jobstore', required=True,  # differs subtly from launch-pipeline's --jobstore
                            help='Name of jobstore')
     metric_sp.add_argument('--namespace', default=os.environ.get('CGCLOUD_NAMESPACE', '/'),
                            help='CGCloud NameSpace')
+    metric_sp.add_argument('--spark-sample-slots', required=False, default=0, type=int,
+                           help='The maximum number of samples to be computed concurrently on a standalone Spark '
+                                'cluster managed by this script. To be used in conjunction with the --master_ip=auto '
+                                'option of the launch-cluster command. The default of 0 disables the standalone Spark '
+                                'cluster.')
 
-    # Common options        
+    # Common options
     for sp in cluster_sp, pipeline_sp, metric_sp:
         sp.add_argument('-c', '--cluster-name', required=True,
                         help='The CGCloud cluster name for Toil leader and workers.')
@@ -498,7 +572,9 @@ def main():
                         help='Worker instance type, e.g. m4.large or c3.8xlarge.')
     for sp in metric_sp, cluster_sp:
         sp.add_argument('-etc', '--add-to-etc-hosts', default=None, required=False,
-                        help='Optional entry to add to /etc/hosts')
+                        help='Deprecated. Optional entry to add to /etc/hosts on Toil workers. This should *not* be '
+                             'used to communicate the address of a standalone Spark master to driver jobs running on '
+                             'Toil nodes. Use --master_ip=auto instead.')
 
     params = parser.parse_args()
 

--- a/src/toil_scripts/adam_uberscript/automated_scaling.py
+++ b/src/toil_scripts/adam_uberscript/automated_scaling.py
@@ -1,228 +1,501 @@
-# Audrey Musselman-Brown
-#
-
-import time
-import boto.sdb
-import boto.exception
-import threading
-from collections import OrderedDict
 import sys
+import threading
+import time
+from collections import OrderedDict
+from itertools import count
 
-class Samples(object):
+import boto.sdb
+from boto.exception import SDBResponseError
+from boto.sdb.domain import Domain
+from collections import Iterator
 
-    def __init__(self, conn, dom, version, samples):
-        self.conn = conn
-        self.dom = dom
-        self.version = version
-        self.samples = samples
+
+class Model(object):
+    """
+    Base class for models that piggy-back their persistence to a Toil AWS job store.
+    """
 
     @classmethod
-    def load(cls, conn, dom):
-        nodes_per_sample = dom.get_attributes("nodes_per_sample", consistent_read=True)
-        if 'version' in nodes_per_sample:
-            version = int(nodes_per_sample.pop('version'))
-        else:
-            version = 0
-        samples = OrderedDict(map(lambda x:[x[0], map(int, x[1].split(','))],
-                                  sorted(nodes_per_sample.items(),
-                                         key=(lambda x: x[1])))) 
-        return cls(conn, dom, version, samples)
-    
-    def save(self):
-        attributes = dict({key: "{0},{1}".format(value[0], value[1])
-                           for key, value in self.samples.items()},
-                           version=str(self.version + 1))
-        try:
-            self.dom.put_attributes("nodes_per_sample", attributes,
-                                    expected_value=('version', str(self.version) if self.version else False))
+    def _get_toil_jobstore_domain(cls):
+        aws, region, domain = sys.argv[1].split(':', 3)
+        conn = boto.sdb.connect_to_region(region)
+        domain = conn.get_domain(domain + '--files')
+        return domain
 
-            self.samples = OrderedDict(sorted(self.samples.items(),
-                                              key=(lambda x: x[1])))
+
+class Sample(object):
+    def __init__(self, sample_id, index, nodes):
+        super(Sample, self).__init__()
+        self.sample_id = sample_id
+        self.index = index
+        self.nodes = nodes
+
+    @classmethod
+    def from_attribute(cls, name, value):
+        index, nodes = map(int, value.split(':', 1))
+        return cls(sample_id=str(name), index=index, nodes=nodes)
+
+    def to_attribute(self):
+        return self.sample_id, '%i:%i' % (self.index, self.nodes)
+
+    def __repr__(self):
+        return 'Sample(sample_id={0.sample_id!r}, index={0.index!r}, nodes={0.nodes!r}'.format(self)
+
+
+class Samples(Model):
+    """
+    Tracks the number of Toil worker nodes requested per sample and a prioritization ordering among those samples in
+    which they are assigned existing nodes.
+
+    >>> sdb = boto.sdb.connect_to_region('us-west-2')
+    >>> domain = sdb.create_domain('SamplesTest')
+    >>> samples = Samples.load(domain); samples
+    Samples(version=0, value=OrderedDict())
+    >>> cluster_size = ClusterSize.load(domain)
+    >>> cluster_size.value, cluster_size.version
+    (0, 0)
+
+    Make the cluster sufficiently large to prevent increase_nodes() from hanging
+    >>> cluster_size.value = 8; cluster_size.save()
+    >>> samples.increase_nodes('b', 1, domain)
+    >>> samples = Samples.load(domain); samples # doctest: +NORMALIZE_WHITESPACE
+    Samples(version=1, value=OrderedDict([('b', Sample(sample_id='b', index=1, nodes=1)]))
+
+    >>> samples.increase_nodes('a', 1, domain)
+    >>> samples = Samples.load(domain); samples # doctest: +NORMALIZE_WHITESPACE
+    Samples(version=2, value=OrderedDict([('b', Sample(sample_id='b', index=1, nodes=1),
+                                          ('a', Sample(sample_id='a', index=2, nodes=1)]))
+
+    >>> samples.increase_nodes('c', 1, domain)
+    >>> samples = Samples.load(domain); samples # doctest: +NORMALIZE_WHITESPACE
+    Samples(version=3, value=OrderedDict([('b', Sample(sample_id='b', index=1, nodes=1),
+                                          ('a', Sample(sample_id='a', index=2, nodes=1),
+                                          ('c', Sample(sample_id='c', index=3, nodes=1)]))
+
+    >>> samples.increase_nodes('a', 2, domain)
+    >>> samples = Samples.load(domain); samples # doctest: +NORMALIZE_WHITESPACE
+    Samples(version=4, value=OrderedDict([('b', Sample(sample_id='b', index=1, nodes=1),
+                                          ('c', Sample(sample_id='c', index=3, nodes=1),
+                                          ('a', Sample(sample_id='a', index=4, nodes=3)]))
+
+    >>> samples.increase_nodes('b', 3, domain)
+    >>> samples = Samples.load(domain); samples # doctest: +NORMALIZE_WHITESPACE
+    Samples(version=5, value=OrderedDict([('c', Sample(sample_id='c', index=3, nodes=1),
+                                          ('a', Sample(sample_id='a', index=4, nodes=3),
+                                          ('b', Sample(sample_id='b', index=5, nodes=4)]))
+
+    >>> samples.decrease_nodes('a', 3, domain)
+    >>> samples = Samples.load(domain); samples # doctest: +NORMALIZE_WHITESPACE
+    Samples(version=6, value=OrderedDict([('c', Sample(sample_id='c', index=3, nodes=1),
+                                          ('a', Sample(sample_id='a', index=4, nodes=0),
+                                          ('b', Sample(sample_id='b', index=5, nodes=4)]))
+
+    >>> samples.decrease_nodes('b', 4, domain)
+    >>> samples = Samples.load(domain); samples # doctest: +NORMALIZE_WHITESPACE
+    Samples(version=7, value=OrderedDict([('c', Sample(sample_id='c', index=3, nodes=1),
+                                          ('a', Sample(sample_id='a', index=4, nodes=0),
+                                          ('b', Sample(sample_id='b', index=5, nodes=0)]))
+
+    >>> domain.delete()
+    True
+    """
+
+    def __init__(self, domain, version, value):
+        self.domain = domain
+        self.version = version
+        self.value = value
+
+    @classmethod
+    def load(cls, domain):
+        attributes = domain.get_attributes('nodes_per_sample', consistent_read=True)
+        version = int(attributes.pop('version', '0'))
+        samples = [Sample.from_attribute(k, v) for k, v in attributes.iteritems()]
+        return cls(domain, version, cls._reindex(samples))
+
+    @classmethod
+    def _reindex(cls, samples):
+        return OrderedDict((sample.sample_id, sample) for sample in
+                           sorted(samples, key=lambda sample: (sample.index, sample.sample_id)))
+
+    def save(self):
+        attributes = dict((sample.to_attribute() for sample in self.value.itervalues()),
+                          version=str(self.version + 1))
+        try:
+            self.domain.put_attributes('nodes_per_sample', attributes,
+                                       expected_value=('version', str(self.version) if self.version else False))
+            self.value = self._reindex(self.value.values())
             self.version += 1
-            return True
-        except boto.exception.SDBResponseError as e:
+        except SDBResponseError as e:
             if e.error_code == 'ConditionalCheckFailed':
                 return False
             else:
                 raise
+        else:
+            return True
 
     @classmethod
-    def increase_nodes(cls, sampleID, n):
+    def increase_nodes(cls, sample_id, n, domain=None):
         """
-        Increases the node count for sampleID by n and returns once the nodes
-        become available
-        This method can ONLY be called from within a toil script
+        Increases the node count for the specified sample and returns once the nodes become available. This method
+        can ONLY be called from within a job function or method in a Toil script because it assumes that it has
+        access to the worker process' command line arguments.
         """
-        
-        aws, region, domain = sys.argv[1].split(':')
-        conn = boto.sdb.connect_to_region(region)
-        dom = conn.get_domain("{0}--files".format(domain))
+        domain = domain or cls._get_toil_jobstore_domain()
 
         while True:
             # load nodes per sample from sdb
-            nodes_per_sample = cls.load(conn, dom)
+            self = cls.load(domain)
 
             # update or insert new nodes
-            if sampleID in nodes_per_sample.samples:
-                nodes_per_sample.samples[sampleID][0] = nodes_per_sample.version + 1
-                nodes_per_sample.samples[sampleID][1] += n
+            if sample_id in self.value:
+                self.value[sample_id].index = self.version + 1
+                self.value[sample_id].nodes += n
             else:
-                nodes_per_sample.samples[sampleID] = [nodes_per_sample.version + 1, n]
+                self.value[sample_id] = Sample(sample_id=sample_id, index=self.version + 1, nodes=n)
 
             # attempt to write back to sdb; retry if failed
-            if nodes_per_sample.save():
+            if self.save():
                 break
 
         while True:
-            # get the current cluster size
-            cluster_size = ClusterSize.load(conn, dom)
-
+            cluster_size = ClusterSize.load(domain)
             sum = 0
-            for sample, [sample_version, nodes] in nodes_per_sample.samples.items():
-                sum += nodes
-                if sample == sampleID and sum <= cluster_size.size:    
+            # noinspection PyUnboundLocalVariable
+            for sample in self.value.itervalues():
+                sum += sample.nodes
+                if sample.sample_id == sample_id and sum <= cluster_size.value:
                     return
-                if sum > cluster_size.size:
+                if sum > cluster_size.value:
                     break
-            nodes_per_sample = cls.load(conn,dom)
-            time.sleep(2)
+            self = cls.load(domain)
+            time.sleep(10)
 
     @classmethod
-    def decrease_nodes(cls, sampleID, n):
+    def decrease_nodes(cls, sample_id, n, domain=None):
         """
-        Decreases the node count for sampleID by n
+        Decrease the node count for the given sample
         """
-
-        aws, region, domain = sys.argv[1].split(':')
-        conn = boto.sdb.connect_to_region(region)
-        dom = conn.get_domain("{0}--files".format(domain))
-
+        domain = domain or cls._get_toil_jobstore_domain()
         while True:
-            nodes_per_sample = cls.load(conn, dom)
-            nodes_per_sample.samples[sampleID][1] -= n
-            print "decrease", nodes_per_sample.samples
-            nodes_per_sample.samples[sampleID][1] = min(nodes_per_sample.samples[sampleID], 0)
-            if nodes_per_sample.save():
+            self = cls.load(domain)
+            sample = self.value[sample_id]
+            sample.nodes = min(sample.nodes - n, 0)
+            if self.save():
                 break
 
+    def __repr__(self):
+        return 'Samples(version={0.version!r}, value={0.value!r})'.format(self)
 
-class ClusterSize(object):
 
-    def __init__(self, conn, dom, version, size):
-        self.conn = conn
-        self.dom = dom
-        self.version = version
-        self.size = size
+class ConcurrentModificationException(Exception):
+    pass
+
+
+class NoSuchSingletonException(Exception):
+    def __init__(self, item_name):
+        super(NoSuchSingletonException, self).__init__('Singleton %s does not exist' % item_name)
+
+
+class SingletonModel(Model):
+    default = None
+    """
+    Subclasses should set this to prevent an exception during load() when the singleton doesn't exist
+    """
 
     @classmethod
-    def load(cls, conn, dom):
-        cluster_size = dom.get_attributes("cluster_size", consistent_read=True)
-        if 'version' in cluster_size:
-            version = int(cluster_size['version'])
-        else:
-            version = 0
-        if 'size' in cluster_size:
-            size = int(cluster_size['size'])
-        else:
-            size = 0
-        return cls(conn, dom, version, size)
+    def create(cls, domain, value):
+        return cls(domain, value, version=0)
 
-
-    def save(self):
-        attributes = dict(size=str(self.size), version=str(self.version+1))
+    @classmethod
+    def load(cls, domain):
+        item_name = cls._item_name()
+        attributes = domain.get_attributes(item_name, consistent_read=True)
         try:
-            self.dom.put_attributes("cluster_size", attributes,
-                                    expected_value=('version', str(self.version) if self.version else False))
-            return True
-        except boto.exception.SDBResponseError as e:
+            value = attributes['value']
+        except KeyError:
+            if cls.default is None:
+                raise NoSuchSingletonException(item_name)
+            else:
+                value = cls.default
+        else:
+            value = str(value)  # suppress unicode
+            value = cls._from_string(value)
+        return cls(domain, value, version=int(attributes.get('version', '0')))
+
+    @classmethod
+    def load_in_toil(cls):
+        """
+        Same as load() but to be used from within a job function of a Toil user script.
+        """
+        return cls.load(cls._get_toil_jobstore_domain())
+
+    def __init__(self, domain, value, version):
+        self.domain = domain
+        self.value = value
+        self.version = version
+
+    def save(self, force=False):
+        """
+        :param force: If False, only save this singleton if the underlying item was not modified since this instance
+        was loaded from it and raise ConcurrentModificationException if it was. If True, don't detect concurrent
+        modifications and simply write the current value and version.
+        """
+        try:
+            item_name = self._item_name()
+            self.domain.put_attributes(
+                item_name=item_name,
+                expected_value=None if force else ('version', str(self.version) if self.version else False),
+                attributes=dict(value=self._from_string(self.value), version=str(self.version + 1)))
+        except SDBResponseError as e:
             if e.error_code == 'ConditionalCheckFailed':
-                return False
+                raise ConcurrentModificationException
             else:
                 raise
 
     @classmethod
-    def change_size(cls, conn, dom, n):
-        while True:
-            cluster_size = cls.load(conn, dom)
-            cluster_size.size = n
-            if cluster_size.save():
-                break
+    def _from_string(cls, value):
+        return value
+
+    @classmethod
+    def _to_string(cls, value):
+        return str(value)
+
+    @classmethod
+    def _item_name(cls):
+        return cls.__name__
 
 
-def test_cluster_size(conn, dom):
+class SingletonIntegerModel(SingletonModel):
+    """
+    >>> sdb = boto.sdb.connect_to_region('us-west-2')
+    >>> domain = sdb.create_domain('SingletonIntegerModelTest')
+    >>> SingletonIntegerModel.load(domain).value
+    Traceback (most recent call last):
+    ...
+    NoSuchSingletonException: Singleton SingletonIntegerModel does not exist
+    >>> domain.delete()
+    True
+    """
+
+    @classmethod
+    def _from_string(cls, value):
+        return int(value)
+
+
+class ClusterSize(SingletonIntegerModel):
+    """
+    Caches the actual cluster size so we can avoid listing instances all the time
+    """
+    default = 0
+
+
+class SparkMasterAddress(SingletonModel):
+    """
+    The current address of the external Spark master.
+
+    >>> sdb = boto.sdb.connect_to_region('us-west-2')
+    >>> domain = sdb.create_domain('SparkMasterAddressTest')
+    >>> a1=SparkMasterAddress.load(domain)
+    >>> a1.value
+    ''
+    >>> a1.value = 'foo'
+    >>> a1.save()
+    >>> a2 = a1.load(domain)
+    >>> a2.value
+    'foo'
+    >>> a2.value = 'bar'
+    >>> a2.save()
+    >>> a2 = SparkMasterAddress.load(domain)
+    >>> a2.value
+    'bar'
+    >>> a1.value
+    'foo'
+    >>> a1.save()
+    Traceback (most recent call last):
+    ...
+    ConcurrentModificationException
+    >>> a1.save(force=True)
+    >>> a2 = SparkMasterAddress.load(domain)
+    >>> a2.value
+    'foo'
+    >>> domain.delete()
+    True
+    """
+    default = ''
+
+
+class Semaphore(Model):
+    """
+    A semaphore implementation that uses optimistic locking of a single item in a SimpleDB domain. Instances of this 
+    class are not thread-safe. 
     
-    i=0
-    while i < 7:
-        cluster_size = ClusterSize.load(conn, dom)
-        nodes_per_sample = Samples.load(conn, dom)        
-        node_requests = sum(map(lambda (v,n): n, nodes_per_sample.samples.values()))
-        if cluster_size.size != node_requests:
-            print "changing cluster size from", cluster_size.size, "to", node_requests
-            i += 1
-            cluster_size.change_size(conn, dom, node_requests)
+    >>> sdb = boto.sdb.connect_to_region('us-west-2')
+    >>> domain = sdb.create_domain('SemaphoreTest')
+    >>> sem1 = Semaphore.create(domain,'foo',overwrite=True)
+    
+    >>> sem1.value
+    0
+    
+    >>> for attempt in sem1.release(1): 
+    ...     assert False # shouldn't happen since no one else is using the semaphore 
+    >>> sem1.value
+    1
+    
+    >>> for attempt, concurrent in sem1.acquire(1): 
+    ...     raise # shouldn't happen since no one else is using the semaphore and we know what its value is
+    >>> sem1.value
+    0
+    
+    Create another semaphore instance representing the same SDB item and start a thread filling it up.
+    
+    >>> sem2 = Semaphore.load(domain,'foo')
+    >>> def writer():
+    ...     for i in range(10):
+    ...         time.sleep(1)
+    ...         for attempt in sem2.release(1):
+    ...             pass # Retry immediately on concurrent updates.
+    >>> thread = threading.Thread(target=writer)
+    >>> thread.start()
+    >>> for i in range(10):
+    ...     for attempt, concurrent in sem1.acquire(1):
+    ...         if not concurrent: # Retry immediately on concurrent updates ...
+    ...             time.sleep(1)  # ... but sleep when semaphore value is too small.
+    
+    The writer's instance must reflect the most recent release().
+         
+    >>> thread.join()
+    >>> sem2.value > 0
+    True
+    
+    The reader's instance must reflect the most recent acquire().
+    
+    >>> sem1.value
+    0
 
+    >>> domain.delete()
+    True
+    """
 
-def test_samples(conn, dom):
+    @classmethod
+    def create(cls, domain, name, value=0, overwrite=False):
+        """
+        Create a new semaphore of the specified name in the given SDB domain.
+         
+        :param Domain domain: the SimpleDB domain in which to creating the item to use for the semaphore 
+        :param str name: the name of the semaphore 
+        :param int value: the initial value of the semaphore
+        :param bool overwrite: True if an existing semaphore of the same value should be overwritten
+        :return: an instance of this class representing the initial value of the semaphore 
+        """
+        self = cls(domain, name, value=value, version=0)
+        self._save(expected_value=None if overwrite else ['version', False])
+        return self
+
+    @classmethod
+    def load(cls, domain, name):
+        """
+        Return an instance of this class representing the current value of the semaphore with the specified name in the 
+        given domain. 
         
-    samples_and_nodes = Samples.load(conn, dom)
-    cluster_size = ClusterSize.load(conn, dom)
-    print "samples and cluster size loaded"
-    print "initial nodes", samples_and_nodes.samples, samples_and_nodes.version
-    print "initial cluster size", cluster_size.size, cluster_size.version
+        :param Domain domain: the SimpleDB domain in which to creating the item to use for the semaphore
+        :param str name: the name of the semaphore
+        :return: an instance of this class representing the current value of the semaphore
+        """
+        self = cls(domain, name)
+        self._load()
+        return self
 
-    print "~~~~~~~~~~~~~~increase  sample 2 nodes by 1~~~~~~~~~~~~~~~~~~~~"
-    samples_and_nodes.increase_nodes("2", 1)
-    samples_and_nodes = Samples.load(conn, dom)
-    print "updated:", samples_and_nodes.samples, samples_and_nodes.version
+    @classmethod
+    def load_in_toil(cls, name):
+        """
+        Same as load() but to be used from within a job function of a Toil script.
+        """
+        return cls.load(cls._get_toil_jobstore_domain(), name)
 
-    print "~~~~~~~~~~~~~~increase  sample 1 nodes by 1~~~~~~~~~~~~~~~~~~~~"
-    samples_and_nodes.increase_nodes("1", 1)
-    samples_and_nodes = Samples.load(conn, dom)    
-    print "updated:", samples_and_nodes.samples, samples_and_nodes.version
+    def acquire(self, delta=1):
+        """
+        Repeatedly attempt to decrease the semaphore by the given amount until successful. 
+        
+        Yield a a tuple ``(attempt, concurrent)`` for every failed attempt where ``attempt`` is a 0-based index of 
+        the current attempt and ``concurrent`` is True if the attempt failed because the underlying SDB item was 
+        updated concurrently, or False if the attempt failed because the semaphore value isn't large enough to 
+        acquire the given delta.
 
-    print "~~~~~~~~~~~~~~increase  sample 3 nodes by 1~~~~~~~~~~~~~~~~~~~~"
-    samples_and_nodes.increase_nodes("3", 1)
-    samples_and_nodes = Samples.load(conn, dom)
-    print "updated:", samples_and_nodes.samples, samples_and_nodes.version
+        :param int delta: the amount to decrease the semaphore by 
+        :rtype: Iterator[(int,bool)] 
 
-    print "~~~~~~~~~~~~~~increase  sample 1 nodes by 2~~~~~~~~~~~~~~~~~~~~"
-    samples_and_nodes.increase_nodes("1", 2)
-    samples_and_nodes = Samples.load(conn, dom)
-    print "updated:", samples_and_nodes.samples, samples_and_nodes.version
+        Using acquire() in a non-blocking fashion:
+        
+        for (attempt, concurrent) in sem.acquire():
+           reurn False
+        return True
+         
+        Delaying retries (recommended):
+         
+        for (attempt, concurrent) in sem.acquire():
+                time.sleep(1 if concurrent else 10)
 
-    print "~~~~~~~~~~~~~~increase  sample 2 nodes by 3~~~~~~~~~~~~~~~~~~~~"
-    samples_and_nodes.increase_nodes("2", 3)
-    samples_and_nodes = Samples.load(conn, dom)
-    print samples_and_nodes.samples, samples_and_nodes.version
+        """
+        for attempt in count():
+            if self.value < delta:
+                yield attempt, False
+                self._load()
+            else:
+                self.value -= delta
+                self.version += 1
+                if self._update():
+                    break
+                else:
+                    yield attempt, True
 
-    print "~~~~~~~~~~~~~~decrease  sample 1 nodes by 3~~~~~~~~~~~~~~~~~~~~"
-    samples_and_nodes.decrease_nodes("1", 3)
-    samples_and_nodes = Samples.load(conn, dom)
-    print samples_and_nodes.samples, samples_and_nodes.version
+    def release(self, delta=1):
+        """
+        Repeatedly attempt to increase the semaphore by the given amount until successful. 
+        
+        For every attempt that fails due to a concurrent update to the underlying SDB item, yield the 0-based index 
+        of the current attempt. 
 
-    print "~~~~~~~~~~~~~~decrease  sample 2 nodes by 4~~~~~~~~~~~~~~~~~~~~"
-    samples_and_nodes.decrease_nodes("2", 4)
-    samples_and_nodes = Samples.load(conn, dom)
-    print samples_and_nodes.samples, samples_and_nodes.version
+        :param int delta: the amount to decrease the semaphore by 
+        :rtype: Iterator[(int,bool)] 
+        """
+        for attempt in count():
+            self.value += delta
+            self.version += 1
+            if self._update():
+                break
+            yield attempt
 
+    def __init__(self, domain, name, value=None, version=None):
+        self.domain = domain
+        self.name = name
+        self.value = value
+        self.version = version
 
-if __name__=="__main__":
+    def _update(self):
+        try:
+            self._save(expected_value=['version', self.version - 1])
+        except SDBResponseError as e:
+            if e.error_code == 'ConditionalCheckFailed':
+                self._load()
+                return False
+            else:
+                raise
+        else:
+            return True
 
-    aws, region, domain = sys.argv[1].split(':')
-    conn = boto.sdb.connect_to_region(region)
-    dom = conn.create_domain("{0}--files".format(domain))
+    def _load(self):
+        attributes = self.domain.get_attributes(item_name=self._item_name,
+                                                consistent_read=True)
+        self.version = int(attributes['version'])
+        self.value = int(attributes['value'])
 
-    dom.delete_attributes("cluster_size")
-    dom.delete_attributes("nodes_per_sample")
-    print "attributes deleted"
+    def _save(self, **put_attributes_kwargs):
+        attributes = dict(version=str(self.version),
+                          value=str(self.value))
+        self.domain.put_attributes(item_name=self._item_name,
+                                   attributes=attributes,
+                                   **put_attributes_kwargs)
 
-    #test_cluster_size(conn,dom)
-    cluster_size_thread = threading.Thread(target=test_cluster_size, args=(conn, dom))
-    samples_thread = threading.Thread(target=test_samples, args=(conn, dom))
-    cluster_size_thread.start()
-    samples_thread.start()
-    cluster_size_thread.join()
-    samples_thread.join()
-
-    conn.delete_domain("{0}--files".format(domain))
-    sys.exit()
+    @property
+    def _item_name(self):
+        return 'semaphore_' + self.name


### PR DESCRIPTION
Resolves #152 

We now distinguish between *dynamic* ("Spark-on-Toil") and *static* clusters. Within the latter we further distinguish between *standalone* and *external*. A standalone cluster is managed by the überscript. This PR obsoletes the `--add-to-etc-hosts` parameter and replaces it with `--master_ip=auto` to indicate standalone clusters. That special string is resolved in the Toil scripts using SimpleDB (the SparkMasterAddress model) and injected into the driver containers via Docker's `--add-host` option. For that I had to dig a little deeper into my OO magic bag of trick. Apologies for that.

This PR creates the standalone Spark master when it is needed. This has the advantage that it will be recreated if needed and that it does not sit idle during alignment.

This has not been tested. The doctests pass, though, needless to say.