### PR TITLE
Fixing TypeError in uberscript logging.

### DIFF
--- a/src/toil_scripts/adam_uberscript/adam_uberscript.py
+++ b/src/toil_scripts/adam_uberscript/adam_uberscript.py
@@ -271,7 +271,7 @@ def grow_cluster(nodes, instance_type, cluster_name, etc):
             time.sleep(5 * 60)
         assert added_nodes <= nodes_left
         nodes_left -= added_nodes
-        log.info('Added {} node(s), {} node(s) left.', added_nodes, nodes_left)
+        log.info('Added %d node(s), %d node(s) left.', added_nodes, nodes_left)
     log.info('Successfully grew cluster by %i node(s) of type %s.', nodes, instance_type)
 
 


### PR DESCRIPTION
```
>>> added_nodes = 1
>>> nodes_left = 1
>>> 'Added {} node(s), {} node(s) left.' % (added_nodes, nodes_left)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: not all arguments converted during string formatting
>>> 'Added %d node(s), %d node(s) left.' % (added_nodes, nodes_left)
'Added 1 node(s), 1 node(s) left.'
```

¯\\_(ツ)_/¯