### PR TITLE
Refactor BWA pipeline (resolves #225, resolves #246)

### DIFF
--- a/src/toil_scripts/batch_alignment/README.md
+++ b/src/toil_scripts/batch_alignment/README.md
@@ -1,88 +1,47 @@
 ## University of California, Santa Cruz Genomics Institute
-### Guide: Running GATK-compatible Alignment 
+### GATK-compatible Alignment
 
-This guide attempts to walk the user through running this pipeline from start to finish. If there are any questions
-please contact John Vivian (jtvivian@gmail.com). If you find any errors or corrections please feel free to make a 
-pull request.  Feedback of any kind is appreciated.
+If there are any questions please contact John Vivian (jtvivian@gmail.com). 
+If you find any errors or corrections please feel free to make a pull request.  
+Feedback of any kind is appreciated.
 
 ## Overview
+
 This pipeline accepts two fastq files (by URL) to be aligned into a BAMFILE, which is the final output of the pipeline.
-A launch script is provided for 3 different references (b37, hg19, hg38).
+A launch script is provided for 4 different references (b37, hg19, hg38, and hg38 no alternative loci).
 
 ## Dependencies
+
 This pipeline has been tested on Ubuntu 14.04, but should also run on other unix based systems.  `apt-get` and `pip`
 often require `sudo` privilege, so if the below commands fail, try prepending `sudo`.  If you do not have sudo 
 privileges you will need to build these tools from source, or bug a sysadmin (they don't mind). 
 
 #### General Dependencies
+
     1. Python 2.7
     2. Curl     apt-get install curl
     3. Docker   http://docs.docker.com/engine/installation/
     
 #### Python Dependencies
+
     1. Toil     pip install toil
     2. S3AM     pip install --pre s3am (optional, for upload of BAMFILE to S3)
  
-## Getting Started
-#### Aligning one sample locally
-From the BD2KGenomics toil-scripts Github repository, download the following files to the same directory.
+## Output
 
-    1. toil-scripts/batch-alignment/bwa_alignment.py
-    2. toil-scripts/batch-alignment/launch_bwa_hg19.sh
-    3. toil-scripts/batch-alignment/bwa_config.csv
-    
-The bash script `launch_bwa_hg19.sh` contains all of the parameters required to run this pipeline, although you 
-will likely want to modify a couple lines as it assumes everything will be staged from your home directory.
+This pipeline produces a BAMFILE for a given sample.
 
-| Parameter                 | Function                                                                                                                              |
-|---------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| 1st argument (unlabelled) | Path to where the jobStore will exist.  The jobStore hosts intermediate files during runtime                                          |
-| `--config`                | Path to the config file. With the format:  UUID,url_to_fastq1,url_to_fastq2                                                           |
-| `--retryCount`            | OPTIONAL: Number of times a failed job will retried. Useful for non-systemic failures (HTTP requests, etc)                            |
-| `--ssec`                  | OPTIONAL: Path to a master key if input files are encrypted in S3                                                                     |
-| `--output_dir`            | OPTIONAL: Directory where final output of pipeline will be placed                                                                     |
-| `--s3_dir`                | OPTIONAL: S3 "Directory" (bucket + directories)                                                                                       |
-| `--workDir`               | OPTIONAL: Location where tmp files will be placed during pipeline run.,If not used, defaults to TMPDIR environment variable.          |
-| `--sudo`                  | OPTIONAL: Prepends "sudo" to all docker commands. Necessary if user is not a member of a docker group or does not have root privilege |
-| `--restart`               | OPTIONAL: Restarts pipeline after failure, requires presence of an existing jobStore.                                                 |
+## Running / Help
 
+It is recommended to use the associated launch scripts which provide default arguments needed to run the pipeline. 
+It is likely that the job store positional argument, `--workDir`, and `--output-dir` arguments will need to be modified.
+To run a pipeline after dependencies have been installed, simply:
 
-The first argument (location of the jobStore) and the directory set in `--workDir`, need *plenty* of space to store 
-intermediate files during pipeline execution.  Change those parameters to point to the appropriate scratch space or
-wherever there exists sufficient storage. The servers I have tested on have 700GB of disk space, which is plenty,
-but ultimately this is contingent upon sample size.
+* `git clone https://github.com/BD2KGenomics/toil-scripts`
+* `/toil-scripts/src/toil_scripts/spladder_pipeline/launch_bwa_hg38_no_alt.sh`
 
-#### Running a sample on a batch system (gridEngine, Parasol, etc).
-To run your pipeline using the gridEngine batch system, simply add the argument `--batchSystem=gridEngine` to the launch
-script.  We currently support Grid Engine, Parasol, and Mesos. 
+Due to PYTHONPATH issues, help can be found by typing:
+
+* `cd toil-scripts/src`
+* `python -m toil_scripts.batch_alignment.bwa_alignment --help`
  
-#### Running batches of samples
-`--config` accepts a path to a CSV file that **must** follow the format of one sample 
-per line: UUID,url_to_fastq1,url_to_fastq2
-
-# Advanced: Running the Pipeline on a Distributed Cloud Cluster (using Mesos)
-From the BD2KGenomics toil-scripts Github repository, download the following files which will run on the head node.
-
-    1. toil-scripts/batch-alignment/bwa_alignment.py
-    2. toil-scripts/batch-alignment/launch_bwa_hg19_mesos.sh
-    3. toil-scripts/batch-alignment/bwa_config.csv
-    
-It is outside the scope of this guide to explain how to setup a distributed cloud cluster.  I recommend taking a 
-look at the BD2KGenomics tool: [CGCloud](https://github.com/BD2KGenomics/cgcloud), which can setup a distributed 
-cloud cluster using the Mesos batch system in AWS.  Please do not direct questions related to CGCloud or 
-setting up a distributed cluster to the author of this pipeline. 
-
-A launch script (`launch_bwa_hg19_mesos.sh`) has been prepared that will run on the head node of the Mesos cluster, scheduling jobs to the worker
-nodes that exist within the cluster.
-
-Explanation of additional parameters
-
-| Parameter     | Function                                                                                                                 |
-|---------------|--------------------------------------------------------------------------------------------------------------------------|
-| 1st argument  | This now points to an AWS jobStore                                                                                       |
-| `--batchSystem` | Path to the config csv file OR the sample.tar.  UUID for the sample is based off the filename before the .tar extension. |
-| `--masterIP`    | A boilerplate argument that indicates what port to use                                                                   |
-| `--sseKey`      | OPTIONAL: Encrypts intermediate files when using cloud jobStore.
- 
-## Additional Information
-Launch scripts are provided for alignment to hg19, hg38, and hg38 with no alternative loci. 

--- a/src/toil_scripts/batch_alignment/bwa_alignment.py
+++ b/src/toil_scripts/batch_alignment/bwa_alignment.py
@@ -1,52 +1,160 @@
-#!/usr/bin/env python2.7
-# John Vivian
-# Date: 11/5/2015
-
 """
-Alignment Pipeline with sorting, header fix, and read group addition.
-This pipeline was created from cannabalized portions of Arjun Rao's Precision Immuno Pipeline:
-https://github.com/arkal/docker_scripts/blob/master/precision_immuno.py
-Thanks bro!
+UC Santa Cruz Computational Genomics Lab
+Updated: 4/21/16
+Authors: John Vivian, Frank Nothaft
 
-        0 --> 1 --> 2 --> 3 --> 4
+Alignment of fastq reads via BWAkit
 
-0   bwa alignment to a reference
-1   samtools sam to bam conversion (and sort)
-2   Fix header
-3   Add read groups
-4   Upload to S3
+    0 --> 1 -->(batching)--> 2 --> 3
+
+0   Download shared files
+1   Parse config
+2   Download sample
+3   Run BWAkit
 
 ===================================================================
 :Dependencies:
 curl            - apt-get install curl
-Toil            - pip install --pre toil
+Toil            - pip install toil
 Docker          - http://docs.docker.com/engine/installation/
 
 Optional:
 S3AM            - pip install --s3am (requires ~/.boto config file)
 """
-from __future__ import print_function
 import argparse
-import base64
-from collections import OrderedDict
-import hashlib
 import multiprocessing
 import os
-import errno
-import subprocess
-import shutil
-import tarfile
-import logging
-from toil.job import Job
-from toil_scripts.lib.programs import docker_call, mock_mode
 
-_log = logging.getLogger(__name__)
+from toil.job import Job
+
+from toil_scripts.lib.files import move_files
+from toil_scripts.lib.jobs import map_job
+from toil_scripts.lib.programs import docker_call, mock_mode
+from toil_scripts.lib.urls import download_url_job, s3am_upload
+
+
+def download_shared_files(job, inputs):
+    """
+    Downloads shared files that are used by all samples for alignment
+
+    :param JobFunctionWrappingJob job: Passed by Toil automatically
+    :param Namespace inputs: Input arguments (see main)
+    """
+    job.fileStore.logToMaster('Downloading shared files for aligment.')
+
+    shared_files = [inputs.ref, inputs.amb, inputs.ann, inputs.bwt, inputs.pac, inputs.sa, inputs.fai]
+    if inputs.alt:
+        shared_files.append(inputs.alt)
+
+    shared_ids = []
+    for url in shared_files:
+        shared_ids.append(job.addChildJobFn(download_url_job, url).rv())
+    job.addFollowOnJobFn(parse_config, shared_ids, inputs)
+
+
+def parse_config(job, shared_ids, inputs):
+    """
+    Stores the UUID and urls associated with the input files to be retrieved.
+    Configuration file has one sample per line, with the following format:  UUID,1st_url,2nd_url
+
+    :param JobFunctionWrappingJob job: Passed by Toil automatically
+    :param dict shared_ids: stores FileStoreIDs
+    :param Namespace inputs: Input arguments
+    """
+    samples = []
+
+    with open(inputs.config, 'r') as f_in:
+        for line in f_in:
+            if line.strip():
+                line = line.strip().split(',')
+                assert len(line) == 3, 'Improper formatting. Expected UUID,URl1,URL2. Received: {}'.format(line)
+                uuid = line[0]
+                urls = line[1:]
+                mock_bam = '.'.join(line[1].split('.')[:-2])[:-2] + ".bam"
+                samples.append((uuid, urls, mock_bam))
+    inputs.cores = multiprocessing.cpu_count()
+    job.fileStore.logToMaster('Parsed configuration file.')
+    job.addChildJobFn(map_job, download_sample, samples, inputs, shared_ids, cores=inputs.cores,
+                      memory='1M' if mock_mode() else '20 G', disk=inputs.file_size)
+
+
+def download_sample(job, sample, inputs, ids):
+    """
+    Downloads the sample
+
+    :param JobFunctionWrappingJob job: Passed by Toil automatically
+    :param tuple[str] sample: uuid and URLS for sample
+    :param Namespace inputs: Contains input arguments
+    :param list ids: list of FileStore IDs for shared inputs
+    """
+    uuid, urls, mock_bam = sample
+    inputs.uuid = uuid
+    inputs.mock_bam = mock_bam
+    job.fileStore.logToMaster('Downloading sample: {0}\nStarting BWA Run: {0}'.format(uuid))
+    ids.insert(0, job.addChildJobFn(download_url_job, urls[0], s3_key_path=inputs.ssec, disk=inputs.file_size).rv())
+    ids.insert(1, job.addChildJobFn(download_url_job, urls[1], s3_key_path=inputs.ssec, disk=inputs.file_size).rv())
+    job.addFollowOnJobFn(run_bwa, inputs, ids, cores=inputs.cores, disk=inputs.file_size)
+
+
+def run_bwa(job, inputs, ids):
+    """
+    Aligns two fastqs into a BAMFILE via BWA
+
+    :param JobFunctionWrappingJob job: Passed by Toil automatically
+    :param Namespace inputs: Input arguments (see main)
+    :param list ids: list of FileStore IDs (R1, R2, reference inputs)
+    """
+    work_dir = job.fileStore.getLocalTempDir()
+    file_names = ['r1.fq.gz', 'r2.fq.gz', 'ref.fa', 'ref.fa.amb', 'ref.fa.ann',
+                  'ref.fa.bwt', 'ref.fa.pac', 'ref.fa.sa', 'ref.fa.fai']
+    if inputs.alt:
+        file_names.append('ref.fa.alt')
+
+    for fileStoreID, name in zip(ids, file_names):
+        job.fileStore.readGlobalFile(fileStoreID, os.path.join(work_dir, name))
+
+    # Add read group line
+    rg = "@RG\\tID:{0}\\tLB:{1}\\tPL:{2}\\tPU:{3}\\tSM:{0}".format(inputs.uuid, inputs.library,
+                                                                   inputs.platform, inputs.program_unit)
+
+    # BWA Options
+    opt_args = []
+    if not inputs.skip_sort:
+        opt_args.append('-s')
+    if inputs.trim:
+        opt_args.append('-a')
+    # Call: bwakit
+    parameters = (['-t', str(inputs.cores),
+                   '-R', rg] +
+                  opt_args +
+                  ['-o', '/data/aligned',
+                   '/data/ref.fa',
+                   '/data/r1.fq.gz',
+                   '/data/r2.fq.gz'])
+    outputs = {'aligned.aln.bam': inputs.mock_bam}
+
+    docker_call(tool='quay.io/ucsc_cgl/bwakit:0.7.12--528bb9bf73099a31e74a7f5e6e3f2e0a41da486e',
+                parameters=parameters, inputs=file_names, outputs=outputs, work_dir=work_dir, sudo=inputs.sudo)
+
+    # BWA insists on adding an `*.aln.sam` suffix, so rename the output file
+    output_file = os.path.join(work_dir, '{}.bam'.format(inputs.uuid))
+    os.rename(os.path.join(work_dir, 'aligned.aln.bam'),
+              output_file)
+
+    # Either write file to local output directory or upload to S3 cloud storage
+    job.fileStore.logToMaster('Aligned sample: {}'.format(inputs.uuid))
+    if inputs.output_dir:
+        move_files([output_file], inputs.output_dir)
+    if inputs.s3_dir:
+        s3am_upload(output_file, inputs.s3_dir, s3_key_path=inputs.ssec)
 
 
 def build_parser():
     parser = argparse.ArgumentParser(description=main.__doc__, add_help=True)
     parser.add_argument('-c', '--config', required=True, help='configuration file. One sample per line: uuid,url,url')
-    parser.add_argument('-l', '--lb', required=True, help='the LB (library) entry to go in the BAM header')
+    parser.add_argument('--library', required=True, help='the LB (library) entry to go in the BAM header')
+    parser.add_argument('--program-unit', default='12345', help='Program Unit for BAM header')
+    parser.add_argument('--platform', default='ILLUMINA', help='Platform to put in the read group')
     parser.add_argument('-r', '--ref', required=True, help='Reference fasta file')
     parser.add_argument('-m', '--amb', required=True, help='Reference fasta file (amb)')
     parser.add_argument('-n', '--ann', required=True, help='Reference fasta file (ann)')
@@ -54,626 +162,32 @@ def build_parser():
     parser.add_argument('-p', '--pac', required=True, help='Reference fasta file (pac)')
     parser.add_argument('-a', '--sa', required=True, help='Reference fasta file (sa)')
     parser.add_argument('-f', '--fai', required=True, help='Reference fasta file (fai)')
-    parser.add_argument('-t', '--alt', required=False, help='Alternate file for reference build (alt). Necessary for alt aware alignment.')
-    parser.add_argument('-s', '--ssec', help='Path to Key File for SSE-C Encryption')
-    parser.add_argument('-o', '--output_dir', default=None, help='full path where final results will be output')
-    parser.add_argument('-u', '--sudo', dest='sudo', action='store_true', help='Docker usually needs sudo to execute '
-                                                                               'locally, but not''when running Mesos '
-                                                                               'or when a member of a Docker group.')
-    parser.add_argument('-3', '--s3_dir', default=None, help='S3 Directory, starting with bucket name. e.g.: '
-                                                             'cgl-driver-projects/ckcc/rna-seq-samples/')
-    parser.add_argument('-k', '--use_bwakit', action='store_true', help='Use bwakit instead of the binary build of bwa')
-    parser.add_argument('-se', '--file_size', default='100G', help='Approximate input file size. Should be given as '
-                                                                   '%d[TGMK], e.g., for a 100 gigabyte file, use --file_size 100G')
-    parser.add_argument('--trim', action='store_true', help='Trim adapters. Ony works with --use_bwakit.')
-    parser.add_argument('--skip_sort', action='store_true', help='Skip sorting. Only works with --use_bwakit.')
-    parser.set_defaults(sudo=False)
+    parser.add_argument('-t', '--alt', required=False,
+                        help='Alternate file for reference build (alt). Necessary for alt aware alignment')
+    parser.add_argument('--ssec', default=None, help='Path to Key File for SSE-C Encryption')
+    parser.add_argument('--output-dir', default=None, help='full path where final results will be output')
+    parser.add_argument('--sudo', dest='sudo', default=False, action='store_true',
+                        help='Docker usually needs sudo to execute locally, but not when running Mesos '
+                             'or when a member of a Docker group.')
+    parser.add_argument('--s3-dir', default=None, help='S3 Directory, starting with bucket name. e.g.: '
+                                                       'cgl-driver-projects/ckcc/rna-seq-samples/')
+    parser.add_argument('--file-size', default='50G', help='Approximate input file size. Should be given as %d[TGMK], '
+                                                           'e.g., for a 100 gigabyte file, use --file_size 100G')
+    parser.add_argument('--trim', action='store_true', help='Trim adapters.')
+    parser.add_argument('--skip-sort', action='store_true', default=False, help='Skip sorting.')
     return parser
-
-
-# Convenience functions
-def mkdir_p(path):
-    """
-    It is Easier to Ask for Forgiveness than Permission
-    """
-    try:
-        os.makedirs(path)
-    except OSError as exc:
-        if exc.errno == errno.EEXIST and os.path.isdir(path):
-            pass
-        else:
-            raise
-
-
-def generate_unique_key(master_key_path, url):
-    """
-    Given a master key and a url, this function returns a 32-byte unique key
-
-    master_key_path: str    Absolute path to the Master Key (for S3 Encryption)
-    url: str                S3 URL (format: https://s3-us-west-2.amazonaws.com/<bucket>/<key.name>)
-    """
-    with open(master_key_path, 'r') as f:
-        master_key = f.read()
-    assert len(master_key) == 32, 'Invalid Key! Must be 32 characters. ' \
-                                  'Key: {}, Length: {}'.format(master_key, len(master_key))
-    new_key = hashlib.sha256(master_key + url).digest()
-    assert len(new_key) == 32, 'New key is invalid and is not 32 characters: {}'.format(new_key)
-    return new_key
-
-
-def download_encrypted_file(job, url, key_path):
-    """
-    Downloads encrypted files from S3 via header injection
-
-    url: str        URL to be downloaded
-    key_path: str   Path to the master key needed to derive unique encryption keys per file
-    """
-    work_dir = job.fileStore.getLocalTempDir()
-    file_path = os.path.join(work_dir, os.path.basename(url))
-
-    with open(key_path, 'r') as f:
-        key = f.read()
-    if len(key) != 32:
-        raise RuntimeError('Invalid Key! Must be 32 bytes: {}'.format(key))
-
-    key = generate_unique_key(key_path, url)
-
-    encoded_key = base64.b64encode(key)
-    encoded_key_md5 = base64.b64encode(hashlib.md5(key).digest())
-    h1 = 'x-amz-server-side-encryption-customer-algorithm:AES256'
-    h2 = 'x-amz-server-side-encryption-customer-key:{}'.format(encoded_key)
-    h3 = 'x-amz-server-side-encryption-customer-key-md5:{}'.format(encoded_key_md5)
-    try:
-        subprocess.check_call(['curl', '-fs', '--retry', '5', '-H', h1, '-H', h2, '-H', h3, url, '-o', file_path])
-    except OSError:
-        raise RuntimeError('Failed to find "curl". Install via "apt-get install curl"')
-    assert os.path.exists(file_path)
-    return job.fileStore.writeGlobalFile(file_path)
-
-
-def download_from_url(job, url):
-    """
-    Downloads a URL that was supplied as an argument to running this script in LocalTempDir.
-    After downloading the file, it is stored in the FileStore.
-
-    url: str        URL to be downloaded. filename is derived from URL
-    """
-    work_dir = job.fileStore.getLocalTempDir()
-    file_path = os.path.join(work_dir, os.path.basename(url))
-    if not os.path.exists(file_path):
-        if url.startswith('s3:'):
-            download_from_s3_url(file_path, url)
-        else:
-            try:
-                download_cmd = ['curl', '-fs', '--retry', '5', '--create-dir', url, '-o', file_path]
-                _log.info("Downloading file using command %s." % " ".join(download_cmd))
-                subprocess.check_call(download_cmd)
-            except OSError:
-                raise RuntimeError('Failed to find "curl". Install via "apt-get install curl"')
-    assert os.path.exists(file_path)
-    return job.fileStore.writeGlobalFile(file_path)
-
-
-def return_input_paths(job, work_dir, ids, *args):
-    """
-    Returns the paths of files from the FileStore if they are not present.
-    This function should be unpacked for every item being returned, unless none
-    of the paths are needed in which case it should be unassigned.
-
-    work_dir: str       Path to the current working directory
-    ids: dict           Dictionary of fileStore IDs, accessed by filename (str)
-    *args: str(s)       Files to be retrieved and placed in the current working directory
-    """
-    paths = OrderedDict()
-    for name in args:
-        if not os.path.exists(os.path.join(work_dir, name)):
-            file_path = job.fileStore.readGlobalFile(ids[name], os.path.join(work_dir, name))
-        else:
-            file_path = os.path.join(work_dir, name)
-        paths[name] = file_path
-        if len(args) == 1:
-            return file_path
-
-    return paths.values()
-
-
-def copy_to_output_dir(work_dir, output_dir, uuid=None, files=()):
-    """
-    A list of files to move from work_dir to output_dir.
-
-    work_dir: str       Current working directory
-    output_dir: str     Desired output directory
-    uuid: str           UUID to be prepended to output files. Optional.
-    files: list         List of files (by filename) to be copied to the desired output directory
-    """
-    for fname in files:
-        if uuid is None:
-            shutil.copy(os.path.join(work_dir, fname), os.path.join(output_dir, fname))
-        else:
-            shutil.copy(os.path.join(work_dir, fname), os.path.join(output_dir, '{}.{}'.format(uuid, fname)))
-
-
-def tarball_files(work_dir, tar_name, uuid=None, files=None):
-    """
-    Tars a group of files together into a tarball
-
-    work_dir: str       Current Working Directory
-    tar_name: str       Name of tarball
-    uuid: str           UUID to stamp files with
-    files: str(s)       List of filenames to place in the tarball from working directory
-    """
-    with tarfile.open(os.path.join(work_dir, tar_name), 'w:gz') as f_out:
-        for fname in files:
-            if uuid:
-                f_out.add(os.path.join(work_dir, fname), arcname=uuid + '.' + fname)
-            else:
-                f_out.add(os.path.join(work_dir, fname), arcname=fname)
-
-
-def download_from_s3_url(file_path, url):
-    from urlparse import urlparse
-    from boto.s3.connection import S3Connection
-    s3 = S3Connection()
-    try:
-        parsed_url = urlparse(url)
-        if not parsed_url.netloc or not parsed_url.path.startswith('/'):
-            raise RuntimeError("An S3 URL must be of the form s3:/BUCKET/ or "
-                               "s3://BUCKET/KEY. '%s' is not." % url)
-        bucket = s3.get_bucket(parsed_url.netloc)
-        key = bucket.get_key(parsed_url.path[1:])
-        _log.info("From URL %s, parsed --> %s, bucket %s, key %s", url, parsed_url, bucket, key)
-        key.get_contents_to_filename(file_path)
-    finally:
-        s3.close()
-
-
-# Job Functions
-def download_shared_files(job, input_args):
-    """
-    Downloads shared files that are used by all samples for alignment and places them in the jobstore.
-
-    input_args: dict        Input arguments (passed from main())
-    """
-    shared_files = ['ref.fa', 'ref.fa.amb', 'ref.fa.ann', 'ref.fa.bwt', 'ref.fa.pac', 'ref.fa.sa', 'ref.fa.fai']
-
-    if input_args['ref.fa.alt']:
-        shared_files.append('ref.fa.alt')
-
-    shared_ids = {}
-    for fname in shared_files:
-        url = input_args[fname]
-        shared_ids[fname] = job.addChildJobFn(download_from_url, url).rv()
-    job.addFollowOnJobFn(parse_config, shared_ids, input_args)
-
-
-def parse_config(job, shared_ids, input_args):
-    """
-    Stores the UUID and urls associated with the input files to be retrieved.
-    Configuration file has one sample per line, with the following format:  UUID,1st_url,2nd_url
-
-    shared_ids: dict        Dictionary of fileStore IDs for the shared files downloaded in the previous step
-    input_args: dict        Input argumentts
-    """
-    samples = []
-    config = input_args['config']
-
-    # does the config file exist locally? if not, try to read from job store
-    if not os.path.exists(config):
-
-        work_dir = job.fileStore.getLocalTempDir()
-        config_path = os.path.join(work_dir, 'config.txt')
-        job.fileStore.readGlobalFile(config, config_path)
-        config = config_path
-
-    with open(config, 'r') as f_in:
-        for line in f_in:
-            if line.strip():
-                line = line.strip().split(',')
-                assert len(line) == 3, 'Improper formatting'
-                uuid = line[0]
-                urls = line[1:]
-                mock_bam = '.'.join(line[1].split('.')[:-2])[:-2] + ".bam"
-                samples.append((uuid, urls, mock_bam))
-    input_args['cpu_count'] = multiprocessing.cpu_count()
-    job_vars = (input_args, shared_ids)
-    for sample in samples:
-        job.addChildJobFn(download_inputs, job_vars, sample, cores=input_args['cpu_count'],
-                          memory='1 M' if mock_mode() else '20 G', disk=input_args['file_size'])
-
-
-def download_inputs(job, job_vars, sample):
-    """
-    Downloads the sample inputs (R1.fq.gz and R2.fq.gz)
-
-    job_vars: tuple         Contains the dictionaries: input_args and ids
-    sample: tuple           Contains the uuid (str) and urls (list of strings)
-    """
-    input_args, ids = job_vars
-    uuid, urls, mock_bam = sample
-    input_args['uuid'] = uuid
-    input_args['mock_bam'] = mock_bam
-    for i in xrange(2):
-        if input_args['ssec']:
-            key_path = input_args['ssec']
-            ids['r{}.fq.gz'.format(i+1)] = job.addChildJobFn(download_encrypted_file, urls[i], key_path, disk=input_args['file_size']).rv()
-        else:
-            ids['r{}.fq.gz'.format(i+1)] = job.addChildJobFn(download_from_url, urls[i], disk=input_args['file_size']).rv()
-    job.addFollowOnJobFn(static_dag_declaration, job_vars)
-
-
-def static_dag_declaration(job, job_vars):
-    """
-    Unnecessary static declaration, but done to test out the promise mechanism
-
-    job_vars: tuple         Contains the dictionaries: input_args and ids
-    """
-    # Define
-    input_args, ids = job_vars
-    cores = input_args['cpu_count']
-
-    # if we run with bwakit, we skip conversion and reheadering
-    if input_args['use_bwakit']:
-
-        bwa = job.wrapJobFn(run_bwa, job_vars, cores=cores, disk=input_args['file_size'])
-        
-        # Link
-        job.addChild(bwa)
-    
-    else:
-
-        bwa = job.wrapJobFn(run_bwa, job_vars, cores=cores, disk=input_args['file_size'])
-        conversion = job.wrapJobFn(bam_conversion, job_vars, bwa.rv(), disk=input_args['file_size'])
-        header = job.wrapJobFn(fix_bam_header, job_vars, conversion.rv(), disk=input_args['file_size'])
-        rg = job.wrapJobFn(add_readgroups, job_vars, header.rv(), memory='1M' if mock_mode() else '15G',
-                           disk=input_args['file_size'])
-        
-        # Link
-        job.addChild(bwa)
-        bwa.addChild(conversion)
-        conversion.addChild(header)
-        header.addChild(rg)
-
-
-def copy_or_upload(work_dir, input_args, output_file):
-    """
-    Looks at what input args are defined and uploads the file to its proper location.
-    """
-
-    # Either write file to local output directory or upload to S3 cloud storage
-    if input_args['output_dir']:
-        copy_to_output_dir(work_dir=work_dir,
-                           output_dir=input_args['output_dir'],
-                           files=[output_file])
-
-    if input_args['s3_dir']:
-        upload_to_s3(work_dir,
-                     input_args,
-                     output_file)
-
-
-def run_bwa(job, job_vars):
-    """
-    This module aligns two fastqs into a SAMFILE using Burrows-Wheeler Alignment
-
-    job_vars: tuple         Contains the dictionaries: input_args and ids
-    """
-    # Unpack variables
-    input_args, ids = job_vars
-    work_dir = job.fileStore.getLocalTempDir()
-    sudo = input_args['sudo']
-    cores = input_args['cpu_count']
-    # Retrieve samples
-    return_input_paths(job, work_dir, ids, 'r1.fq.gz', 'r2.fq.gz')
-    # Retrieve input files
-    return_input_paths(job, work_dir, ids, 'ref.fa', 'ref.fa.amb', 'ref.fa.ann',
-                       'ref.fa.bwt', 'ref.fa.pac', 'ref.fa.sa', 'ref.fa.fai')
-
-    inputs = ['ref.fa', 'r1.fq.gz', 'r2.fq.gz', 'ref.fa', 'ref.fa.amb', 'ref.fa.ann',
-              'ref.fa.bwt', 'ref.fa.pac', 'ref.fa.sa', 'ref.fa.fai']
-
-    if input_args['ref.fa.alt']:
-        return_input_paths(job, work_dir, ids, 'ref.fa.alt')
-        inputs.append('ref.fa.alt')
-
-    if input_args['use_bwakit']:
-
-        # add a read group line
-        # this is an illumina only pipeline, therefore, hardcoding illumina is OK
-        # program unit is required by GATK, but we don't know it
-        # so, fake a bad value
-        uuid = input_args['uuid']
-        library = input_args['lb']
-
-        rg = ''
-        if input_args['rg_line']:
-            rg = input_args['rg_line']
-        else:
-            rg = "@RG\\tID:%s\\tLB:%s\\tPL:ILLUMINA\\tPU:12345\\tSM:%s" % (uuid,
-                                                                           library,
-                                                                           uuid)
-        
-        # do we want to use bwakit to sort?
-        opt_args = []
-        if input_args['sort']:
-            opt_args.append('-s')
-
-        # do we want to use bwakit to trim adapters?
-        if input_args['trim']:
-            opt_args.append('-a')
-
-        # Call: bwakit
-        parameters = (['-t%d' % cores,
-                       '-R%s' % rg] +
-                      opt_args +
-                      ['-o', '/data/aligned',
-                       '/data/ref.fa',
-                       '/data/r1.fq.gz',
-                       '/data/r2.fq.gz'])
-        outputs={'aligned.aln.bam': input_args['mock_bam']}
-
-        docker_call(tool='quay.io/ucsc_cgl/bwakit:0.7.12--528bb9bf73099a31e74a7f5e6e3f2e0a41da486e',
-                    parameters=parameters, inputs=inputs, outputs=outputs, work_dir=work_dir, sudo=sudo)
-
-        # bwa insists on adding an `*.aln.sam` suffix, so rename the output file
-        output_file = '{}.bam'.format(uuid)
-        os.rename(os.path.join(work_dir, 'aligned.aln.bam'),
-                  os.path.join(work_dir, output_file))
-        
-        # Either write file to local output directory or upload to S3 cloud storage
-        copy_or_upload(work_dir, input_args, output_file)
-        
-    else:
-        # Call: BWA
-        parameters = ["mem",
-                      "-t", str(cores),
-                      "/data/ref.fa"] + ['/data/r1.fq.gz', '/data/r2.fq.gz']
-
-        outputs = {'aligned.sam': None}
-        with open(os.path.join(work_dir, 'aligned.sam'), 'w') as samfile:
-            docker_call(tool='quay.io/ucsc_cgl/bwa:0.7.12--dd5ac549b95eb3e5d166a5e310417ef13651994e',
-                        parameters=parameters, inputs=inputs, outputs=outputs, work_dir=work_dir,
-                        outfile=samfile, sudo=sudo)
-
-        # write aligned sam file to global file store
-        return job.fileStore.writeGlobalFile(os.path.join(work_dir, 'aligned.sam'))
-
-
-def bam_conversion(job, job_vars, sam_id):
-    """
-    This module converts SAMFILE to BAMFILE using samtools
-
-    job_vars: tuple         Contains the dictionaries: input_args and ids
-    sam_id: str             FileStore ID for the samfile
-    """
-    # Unpack variables
-    input_args, ids = job_vars
-    work_dir = job.fileStore.getLocalTempDir()
-    sudo = input_args['sudo']
-    # Retrieve input file
-    job.fileStore.readGlobalFile(sam_id, os.path.join(work_dir, 'aligned.sam'))
-    # Call: Samtools
-    parameters = ['view',
-                  '-bS',
-                  '/data/aligned.sam']
-    inputs = ['aligned.sam']
-    outputs = {'aligned.bam': None}
-    with open(os.path.join(work_dir, 'aligned.bam'), 'w') as bamfile:
-        docker_call(tool='quay.io/ucsc_cgl/samtools:1.2--35ac87df5b21a8e8e8d159f26864ac1e1db8cf86',
-                    parameters=parameters, inputs=inputs, outputs=outputs, work_dir=work_dir, outfile=bamfile,
-                    sudo=sudo)
-    return job.fileStore.writeGlobalFile(os.path.join(work_dir, 'aligned.bam'))
-
-
-def fix_bam_header(job, job_vars, bam_id):
-    """
-    This module modified the header in BAMFILE using samtools
-
-    job_vars: tuple         Contains the dictionaries: input_args and ids
-    bam_id: str             FileStore ID for the BAMFILE
-    """
-    # Unpack variables
-    work_dir = job.fileStore.getLocalTempDir()
-    input_args, ids = job_vars
-    sudo = input_args['sudo']
-    # Retrieve input file
-    try:
-        job.fileStore.readGlobalFile(bam_id, os.path.join(work_dir, 'aligned.bam'))
-    except:
-        # remove and retry?
-        try:
-            os.remove(os.path.join(work_dir, 'aligned.bam'))
-        except:
-            pass
-        
-        job.fileStore.readGlobalFile(bam_id, os.path.join(work_dir, 'aligned.bam'))
-    # Call: Samtools
-    parameters = ['view',
-                  '-H',
-                  '/data/aligned.bam']
-
-    inputs = ['aligned.bam']
-    outputs = {'output_bam.header': None}
-    with open(os.path.join(work_dir, 'aligned_bam.header'), 'w') as headerfile:
-        docker_call(tool='quay.io/ucsc_cgl/samtools:1.2--35ac87df5b21a8e8e8d159f26864ac1e1db8cf86',
-                    parameters=parameters, inputs=inputs, outputs=outputs, work_dir=work_dir, outfile=headerfile,
-                    sudo=sudo)
-    with open(headerfile.name, 'r') as headerfile, open('/'.join([work_dir, 'output_bam.header']), 'w') as outheaderfile:
-            for line in headerfile:
-                if line.strip().startswith('@PG'):
-                    line = '\t'.join([x for x in line.strip().split('\t') if not x.startswith('CL')])
-                print(line.strip(), file=outheaderfile)
-    # Call: Samtools
-    parameters = ['reheader',
-                  '/data/output_bam.header',
-                  '/data/aligned.bam']
-    # Memory leak, crashes
-    inputs = ['aligned.bam', 'output_bam.header']
-    outputs = {'aligned_fixPG.bam': None}
-    with open(os.path.join(work_dir, 'aligned_fixPG.bam'), 'w') as fixpg_bamfile:
-        docker_call(tool='quay.io/ucsc_cgl/samtools:1.2--35ac87df5b21a8e8e8d159f26864ac1e1db8cf86',
-                    parameters=parameters, inputs=inputs, outputs=outputs, work_dir=work_dir,
-                    outfile=fixpg_bamfile, sudo=sudo)
-    return job.fileStore.writeGlobalFile(os.path.join(work_dir, 'aligned_fixPG.bam'))
-
-
-def add_readgroups(job, job_vars, bam_id):
-    """
-    This module adds the appropriate read groups to the BAMFILE using picard-tools
-
-    job_vars: tuple         Contains the dictionaries: input_args and ids
-    ban_id: str             FileStore ID for the BAMFILE from the previous step
-    """
-    # Unpack variables
-    work_dir = job.fileStore.getLocalTempDir()
-    input_args, ids = job_vars
-    sudo = input_args['sudo']
-    uuid = input_args['uuid']
-    output_file = '{}.bam'.format(uuid)
-    # Retrieve input file
-    job.fileStore.readGlobalFile(bam_id, os.path.join(work_dir, 'aligned_fixpg.bam'))
-    _log.warn("Read global file to %s, adding read groups and saving to %s." % (os.path.join(work_dir, 'aligned_fixpg.bam'), os.path.join(work_dir, output_file)))
-
-    # Call: Samtools
-    parameters = ['AddOrReplaceReadGroups',
-                  'I=/data/aligned_fixpg.bam',
-                  'O=/data/{}'.format(output_file),
-                  'SO=coordinate',
-                  'ID={}'.format(uuid),
-                  'LB={}'.format(input_args['lb']),
-                  'PL=ILLUMINA',
-                  'PU=12345',
-                  'SM={}'.format(uuid)]
-    inputs = ['aligned_fixPG.bam']
-
-    outputs = {output_file: 's3://adam-gatk-pipeline-mock-files/sequence/mouse_chrM.bam'}
-
-    docker_call(tool='quay.io/ucsc_cgl/picardtools:1.95--dd5ac549b95eb3e5d166a5e310417ef13651994e',
-                parameters=parameters, work_dir=work_dir, env={'JAVA_OPTS':'-Xmx15G'}, sudo=sudo)
-
-    # Either write file to local output directory or upload to S3 cloud storage
-    copy_or_upload(work_dir, input_args, output_file)
-        
-
-def upload_to_s3(work_dir, input_args, output_file):
-    """
-    Uploads a file to S3 via S3AM with encryption.  This pipeline assumes all
-    BAMS contain patient data and must be encrypted upon upload.
-
-    job_vars: tuple         Contains the dictionaries: input_args and ids
-    """
-
-    # Parse s3_dir to get bucket and s3 path
-    s3_dir = input_args['s3_dir']
-    bucket_name = s3_dir.lstrip('/').split('/')[0]
-    bucket_dir = '/'.join(s3_dir.lstrip('/').split('/')[1:])
-
-    # what is the path we are uploading to?
-    s3_path = os.path.join('s3://', bucket_name, bucket_dir, output_file)
-
-    # how many cores should we use?
-    cores = input_args['cpu_count']
-
-    # does this need to be uploaded with encryption?
-    if input_args['ssec']:
-        key_path = input_args['ssec']
-
-        base_url = 'https://s3-us-west-2.amazonaws.com'
-        url = os.path.join(base_url, bucket_name, bucket_dir, output_file)
-
-        # Generate keyfile for upload
-        uuid = input_args['uuid']
-        with open(os.path.join(work_dir, uuid + '.key'), 'wb') as f_out:
-            f_out.write(generate_unique_key(key_path, url))
-
-        # Upload to S3 via S3AM
-        s3am_command = ['s3am',
-                        'upload',
-                        '--sse-key-file', os.path.join(work_dir, uuid + '.key'),
-                        '--part-size=64M',
-                        '--upload-slots={}'.format(cores),
-                        '--download-slots={}'.format(cores),
-                        'file://{}'.format(os.path.join(work_dir, output_file)),
-                        s3_path]
-    else:
-        # Upload to S3 via S3AM
-        s3am_command = ['s3am',
-                        'upload',
-                        '--part-size=64M',
-                        '--upload-slots={}'.format(cores),
-                        '--download-slots={}'.format(cores),
-                        'file://{}'.format(os.path.join(work_dir, output_file)),
-                        s3_path]
-
-    # run upload
-    _log.info("Calling s3am with %s" % " ".join(s3am_command))
-    try:
-        subprocess.check_call(s3am_command)
-    except:
-        _log.error("Upload to %s failed. Cancelling..." % s3_path)
-        s3am_cancel = ['s3am', 'cancel', s3_path]
-        
-        try:
-            subprocess.check_call(s3am_cancel)
-        except:
-            _log.error("Cancelling upload with '%s' failed." % " ".join(s3am_cancel))
-
-        raise
 
 
 def main():
     """
     This is a Toil pipeline used to perform alignment of fastqs.
-    It uses BWA to align, samtools to sort and fix the header,
-    and picard to add the read group (RG) information to the BAM
-    that is in a format compatible with GATK.
-
-    Config: "bwa_config.csv" is a required file that stores sample information to be run.
-    Script: "launch_bwa_hg19.sh" provides all of the inputs needed to run this script locally.
-    Script: "bwa_launch_mesos.sh" provides all of the inputs needed to run this script on a mesos cluster in AWS
     """
     # Define Parser object and add to Toil
     parser = build_parser()
     Job.Runner.addToilOptions(parser)
     args = parser.parse_args()
-
-    # validate bwakit specific args
-    arg_errors = ["Argument validation failed:"]
-    if not args.use_bwakit:
-        if args.alt:
-            arg_errors.append('Alternate haplotype build supplied, but not using bwakit.')
-        if args.skip_sort:
-            arg_errors.append('--skip_sort can only be used with --use_bwakit.')
-        if args.trim:
-            arg_errors.append('--trim can only be used with --use_bwakit.')
-    if len(arg_errors) > 1:
-        raise ValueError("\n".join(arg_errors))
-
-    # Store input parameters in a dictionary
-    inputs = {'config': args.config,
-              'ref.fa': args.ref,
-              'ref.fa.amb': args.amb,
-              'ref.fa.ann': args.ann,
-              'ref.fa.bwt': args.bwt,
-              'ref.fa.pac': args.pac,
-              'ref.fa.sa': args.sa,
-              'ref.fa.fai': args.fai,
-              'ref.fa.alt': args.alt,
-              'ssec': args.ssec,
-              'output_dir': args.output_dir,
-              'sudo': args.sudo,
-              's3_dir': args.s3_dir,
-              'lb': args.lb,
-              'uuid': None,
-              'cpu_count': None,
-              'file_size': args.file_size,
-              'use_bwakit': args.use_bwakit,
-              'sort': not args.skip_sort,
-              'trim': args.trim,
-              'rg_line': None}
-
     # Launch Pipeline
-    Job.Runner.startToil(Job.wrapJobFn(download_shared_files, inputs), args)
+    Job.Runner.startToil(Job.wrapJobFn(download_shared_files, args), args)
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/toil_scripts/batch_alignment/bwa_config.csv
+++ b/src/toil_scripts/batch_alignment/bwa_config.csv
@@ -1,1 +1,1 @@
-DTB-005-BL-T,https://s3-us-west-2.amazonaws.com/cgl-driver-projects-encrypted/wcdt/exome_fastqs/DTB-005-BL-T-DNA_S1_L001_R1_001.fastq.gz,https://s3-us-west-2.amazonaws.com/cgl-driver-projects-encrypted/wcdt/exome_fastqs/DTB-005-BL-T-DNA_S1_L001_R2_001.fastq.gz
+test,https://R1.fastq.gz,https://R2.fastq.gz

--- a/src/toil_scripts/batch_alignment/launch_bwa_hg19.sh
+++ b/src/toil_scripts/batch_alignment/launch_bwa_hg19.sh
@@ -7,7 +7,7 @@ python -m toil_scripts.batch_alignment.bwa_alignment \
 /data/alignment-jobStore \
 --retryCount 2 \
 --config bwa-config.csv \
---lb KapaHyper \
+--library KapaHyper \
 --ref https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/alignment/hg19.fa \
 --amb https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/alignment/hg19.fa.amb \
 --ann https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/alignment/hg19.fa.ann \
@@ -17,5 +17,4 @@ python -m toil_scripts.batch_alignment.bwa_alignment \
 --fai https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/alignment/hg19.fa.fai \
 --workDir /data \
 --ssec /data/master.key \
---output_dir /data \
---use_bwakit
+--output-dir /data

--- a/src/toil_scripts/batch_alignment/launch_bwa_hg19_mesos.sh
+++ b/src/toil_scripts/batch_alignment/launch_bwa_hg19_mesos.sh
@@ -8,7 +8,7 @@ python -m toil_scripts.batch_alignment.bwa_alignment \
 aws:us-west-2:alignment-run-1 \
 --retryCount 2 \
 --config bwa-config.csv \
---lb KapaHyper \
+--library KapaHyper \
 --ref https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/alignment/hg19.fa \
 --amb https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/alignment/hg19.fa.amb \
 --ann https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/alignment/hg19.fa.ann \
@@ -17,9 +17,8 @@ aws:us-west-2:alignment-run-1 \
 --sa https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/alignment/hg19.fa.sa \
 --fai https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/alignment/hg19.fa.fai \
 --ssec /home/mesosbox/shared/master.key \
---s3_dir cgl-driver-projects/test/alignment \
+--s3-dir cgl-driver-projects/test/alignment \
 --sseKey=/home/mesosbox/shared/master.key \
 --batchSystem="mesos" \
 --mesosMaster mesos-master:5050 \
---workDir=/var/lib/toil \
---use_bwakit
+--workDir=/var/lib/toil

--- a/src/toil_scripts/batch_alignment/launch_bwa_hg38.sh
+++ b/src/toil_scripts/batch_alignment/launch_bwa_hg38.sh
@@ -7,7 +7,7 @@ python -m toil_scripts.batch_alignment.bwa_alignment \
 /data/alignment-jobStore \
 --retryCount 2 \
 --config bwa-config.csv \
---lb KapaHyper \
+--library KapaHyper \
 --ref https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/alignment/hg38.fa \
 --amb https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/alignment/hg38.fa.amb \
 --ann https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/alignment/hg38.fa.ann \
@@ -17,5 +17,4 @@ python -m toil_scripts.batch_alignment.bwa_alignment \
 --fai https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/alignment/hg38.fa.fai \
 --workDir /data \
 --ssec /data/master.key \
---output_dir /data \
---use_bwakit
+--output-dir /data

--- a/src/toil_scripts/batch_alignment/launch_bwa_hg38_no_alt.sh
+++ b/src/toil_scripts/batch_alignment/launch_bwa_hg38_no_alt.sh
@@ -4,9 +4,9 @@
 # Please read the associated README.md before attempting to use.
 export PYTHONPATH=$(python -c 'from os.path import abspath as a, dirname as d;import sys;print d(d(d(a(sys.argv[1]))))' $0)
 python -m toil_scripts.batch_alignment.bwa_alignment \
-aws:us-west-2:alignment-run-1 \
+/data/alignment-jstore \
 --retryCount 2 \
---config /home/mesosbox/shared/bwa-config.csv \
+--config /data/bwa-config.cvs \
 --library KapaHyper \
 --ref https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/alignment/hg38_no_alt.fa \
 --amb https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/alignment/hg38_no_alt.fa.amb \
@@ -15,8 +15,6 @@ aws:us-west-2:alignment-run-1 \
 --pac https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/alignment/hg38_no_alt.fa.pac \
 --sa https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/alignment/hg38_no_alt.fa.sa \
 --fai https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/alignment/hg38_no_alt.fa.fai \
---workDir /var/lib/toil \
---ssec /home/mesosbox/shared/master.key \
---batchSystem="mesos" \
---mesosMaster mesos-master:5050 \
---s3-dir cgl-driver-projects/test/alignment
+--workDir /data \
+--ssec /data/master.key \
+--output-dir /data

--- a/src/toil_scripts/batch_alignment/launch_bwakit_grch38.sh
+++ b/src/toil_scripts/batch_alignment/launch_bwakit_grch38.sh
@@ -8,7 +8,7 @@ python -m toil_scripts.batch_alignment.bwa_alignment \
 /data/alignment-jobStore \
 --retryCount 2 \
 --config bwa-config.csv \
---lb LIB \
+--library LIB \
 --ref https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa \
 --amb https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.amb \
 --ann https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.ann \
@@ -17,6 +17,5 @@ python -m toil_scripts.batch_alignment.bwa_alignment \
 --sa https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.sa \
 --fai https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.fai \
 --alt https://s3-us-west-2.amazonaws.com/cgl-pipeline-inputs/variant_grch38/GRCh38_full_analysis_set_plus_decoy_hla.fa.alt \
---use_bwakit \
 --workDir /data \
---output_dir /data
+--output-dir /data

--- a/src/toil_scripts/gatk_germline/germline.py
+++ b/src/toil_scripts/gatk_germline/germline.py
@@ -40,7 +40,7 @@ from collections import OrderedDict
 from toil.job import Job
 
 from toil_scripts import download_from_s3_url
-from toil_scripts.batch_alignment.bwa_alignment import upload_to_s3
+from toil_scripts.lib.urls import s3am_upload
 from toil_scripts.lib.programs import docker_call
 
 def build_parser():
@@ -534,8 +534,10 @@ def upload_or_move_hc(work_dir, input_args, output):
         move_to_output_dir(work_dir, output_dir, output)
 
     elif input_args['s3_dir']:
-        
-        upload_to_s3(work_dir, input_args, output)
+
+        s3am_upload(fpath=os.path.join(work_dir, output),
+                    s3_dir=input_args['s3_dir'],
+                    s3_key_path=input_args['ssec'])
 
     else:
 

--- a/src/toil_scripts/gatk_processing/gatk_preprocessing.py
+++ b/src/toil_scripts/gatk_processing/gatk_preprocessing.py
@@ -18,13 +18,10 @@ Toil pipeline for processing bam files for GATK halpotype calling
 11 = base recalibration
 12 = ouput bqsr file
 """
-
 import argparse
 import collections
 import multiprocessing
-import tarfile
 import os
-import errno
 import hashlib
 import base64
 import subprocess
@@ -35,7 +32,7 @@ import errno
 from toil.job import Job
 
 from toil_scripts import download_from_s3_url
-from toil_scripts.batch_alignment.bwa_alignment import upload_to_s3
+from toil_scripts.lib.urls import s3am_upload
 from toil_scripts.lib.programs import docker_call
 
 _log = logging.getLogger(__name__)
@@ -180,7 +177,9 @@ def upload_or_move(job, work_dir, input_args, output):
         move_to_output_dir(work_dir, output_dir, output)
 
     elif input_args['s3_dir']:
-        upload_to_s3(work_dir, input_args, output)
+        s3am_upload(fpath=os.path.join(work_dir, output),
+                    s3_dir=input_args['s3_dir'],
+                    s3_key_path=input_args['ssec'])
 
     else:
         raise ValueError('No output_directory or s3_dir defined. Cannot determine where to store %s' % output)


### PR DESCRIPTION
Change sphinx type to tuple[str]
Add to logToMaster
Fix call to inputs in resource requirements
Fix call to reference error
Refactor input dict to Namespace
Remove unnecessary argument shortcuts
Change --lb to --library in launch scripts
Remove s3 information from example config
Revamp README
Change tense of logToMaster given display of message to screen
Add back in if __name__ .... boilerplate
Add launch script for no_alt single machine
Add logToMaster to job functions
Remove --pre from pip install toil suggestion
Remove shebang and if __name__ ... boilerplate
Fix CLI and input dict
Rewrite pipeline to use bwakit only
Use common lib for downloading url
Add sphinx docstrings
Fix imports
Fix top-level docstring
Fix launch script arguments
Remove unnecessary bwakit validation steps
Rename download_inputs to download_sample
Use map_job instead of iterating over samples
Clarify assert for input
Simplify sample download
Remove unnecessary static DAG fn and copy_or_upload fn
Remove unnecessary config check if not locally present
Remove functions to replace with common lib
Move parser above main()