### PR TITLE
Make toil-scripts pip installable (resolves #260)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
-/.project
 *.pyc
-*~
-*#*
 *.log
-
+/src/*.egg-info
+.cache/
+.eggs/
+test-report.xml
+__pycache__
+venv/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include version.py

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,103 @@
+# Copyright (C) 2015 UCSC Computational Genomics Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+define help
+
+Supported targets: 'develop', 'sdist', 'clean', 'test', or 'pypi'.
+
+The 'develop' target creates an editable install (aka develop mode).
+
+	make develop
+
+The 'clean' target undoes the effect of 'develop', 'docs', and 'sdist'.
+
+The 'test' target runs Toil-script's unit tests.
+
+The 'pypi' target publishes the current commit of Toil to PyPI after enforcing that the working
+copy and the index are clean, and tagging it as an unstable .dev build.
+
+endef
+export help
+help:
+	@echo "$$help"
+
+
+python=python2.7
+pip=pip2.7
+tests=src
+extras=
+
+green=\033[0;32m
+normal=\033[0m
+red=\033[0;31m
+
+
+develop: check_venv
+	$(pip) install -e .$(extras)
+clean_develop: check_venv
+	- $(pip) uninstall -y toil
+	- rm -rf src/*.egg-info
+
+
+sdist: check_venv
+	$(python) setup.py sdist
+clean_sdist:
+	- rm -rf dist
+
+
+test: check_venv
+	$(python) setup.py test --pytest-args "-vv $(tests) --junitxml=test-report.xml"
+
+
+pypi: check_venv check_clean_working_copy check_running_on_jenkins
+	set -x \
+	&& tag_build=`$(python) -c 'pass;\
+		from version import version as v;\
+		from pkg_resources import parse_version as pv;\
+		import os;\
+		print "--tag-build=.dev" + os.getenv("BUILD_NUMBER") if pv(v).is_prerelease else ""'` \
+	&& $(python) setup.py egg_info $$tag_build sdist bdist_egg upload
+clean_pypi:
+	- rm -rf build/
+
+
+clean: clean_develop clean_sdist clean_pypi
+
+
+check_venv:
+	@$(python) -c 'import sys; sys.exit( int( not hasattr(sys, "real_prefix") ) )' \
+		|| ( echo "$(red)A virtualenv must be active.$(normal)" ; false )
+
+
+check_clean_working_copy:
+	@echo "$(green)Checking if your working copy is clean ...$(normal)"
+	@git diff --exit-code > /dev/null \
+		|| ( echo "$(red)Your working copy looks dirty.$(normal)" ; false )
+	@git diff --cached --exit-code > /dev/null \
+		|| ( echo "$(red)Your index looks dirty.$(normal)" ; false )
+	@test -z "$$(git ls-files --other --exclude-standard --directory)" \
+		|| ( echo "$(red)You have are untracked files:$(normal)" \
+			; git ls-files --other --exclude-standard --directory \
+			; false )
+
+
+check_running_on_jenkins:
+	@echo "$(green)Checking if running on Jenkins ...$(normal)"
+	@test -n "$$BUILD_NUMBER" \
+		|| ( echo "$(red)This target should only be invoked on Jenkins.$(normal)" ; false )
+
+
+.PHONY: help develop clean_develop sdist clean_sdist test \
+		pypi pypi_stable clean_pypi docs clean_docs clean \
+		check_venv check_clean_working_copy check_running_on_jenkins

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 ## University of California, Santa Cruz Genomics Institute
 ### Repository of Toil-based Genomic Pipelines
  
- This repository contains a collection of genomic pipelines developed by the UCSC Computational Genomics Lab.
- These pipelines are used on a regular basis in-house and are freely available to anyone who would like to use
- them.
+This repository contains a collection of genomic pipelines developed by the UCSC Computational Genomics Lab.
 
-Pipelines currently supported for the latest version of Toil:
+To install these pipelines, just type: `pip install toil-scripts`
+
+Entrypoints are supplied to pipelines that work with the current stable release of Toil:
     
-- Fastq to BAM alignment (GATK compatible format)
-- Exome variant pipeline
-- UNC best practices RNA-seq pipeline 
-- Our own best practices RNA-seq pipeline (STAR + RSEM, Kallisto)
-- Germline variant pipeline
+- Fastq to BAM alignment: `toil-bwa`
+- CGL RNA-seq Pipeline (hg38): `toil-rnaseq`
+- UNC best practices RNA-seq pipeline (hg19): `toil-rnaseq-unc` 
+- SplAdder alternative splicing pipeline: `toil-spladder`
+- GATK exome variant pipeline: `toil-variant`
 
-Each pipeline has its own README that provides explicit instructions on how to get up and running. 
+Each pipeline has its own README that provides instructions on how to get up and running. 
 The general dependencies for these pipelines are:
 
 1. [Toil](https://github.com/BD2KGenomics/toil)

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
+
 # Create s3am venv
 virtualenv s3am
-. s3am/bin/activate
-pip install s3am==2.0a1.dev93
-deactivate
-# Create Toil venv
-virtualenv toil
-. toil/bin/activate
-pip install pytest==2.9.1 toil==3.1.4 boto==2.39.0 tqdm==3.8.0
+s3am/bin/pip install s3am==2.0a1.dev93
 # Expose binaries to the PATH
 mkdir bin
 ln -snf ${PWD}/s3am/bin/s3am bin/
 export PATH=$PATH:${PWD}/bin
-# Set PYTHONPATH
-export PYTHONPATH=$(python -c 'from os.path import abspath as a;import sys;print a("src")' $0)
-py.test src --doctest-modules --junitxml=test-report.xml
+
+# Create Toil venv
+virtualenv venv
+. venv/bin/activate
+make develop
+make test
+rm -rf bin s3am
+make pypi
+rm -rf venv

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[metadata]
+description-file = README.md
+
+[pytest]
+# Look for any python file, the default of test_*.py wouldn't work for us
+python_files=*.py
+# Also run doctests
+addopts = --doctest-modules

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,76 @@
+# Copyright (C) 2015 UCSC Computational Genomics Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import sys
+
+from setuptools import find_packages, setup
+from setuptools.command.test import test as TestCommand
+from version import version
+
+toil_version = '3.1.4'
+
+kwargs = dict(
+    name='toil-scripts',
+    version=version,
+    description='A repository of genomic workflows developed by the UCSC Computational Genomics lab ',
+    author='UCSC Computational Genomics Lab',
+    author_email='cgl-toil@googlegroups.com',
+    url="https://github.com/BD2KGenomics/toil-scripts",
+    install_requires=[
+        'toil==' + toil_version,
+        'boto==2.38.0', # FIXME: Make an extra
+        'tqdm==3.8.0'], # FIXME: Remove once ADAM stops using it (superfluous import)
+    tests_require=[
+        'pytest==2.8.3'],
+    package_dir={'': 'src'},
+    packages=find_packages('src', exclude=['*.test']),
+    entry_points={
+        'console_scripts': [
+            'toil-bwa = toil_scripts.batch_alignment.bwa_alignment:main',
+            'toil-rnaseq = toil_scripts.rnaseq_cgl.rnaseq_cgl_pipeline:main',
+            'toil-rnaseq-unc = toil_scripts.rnaseq_unc.rnaseq_unc_pipeline:main',
+            'toil-spladder = toil_scripts.spladder_pipeline.spladder_pipeline:main',
+            'toil-variant = toil_scripts.exome_variant_pipeline.exome_variant_pipeline:main']})
+
+
+class PyTest(TestCommand):
+    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = []
+
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        import pytest
+        # Sanitize command line arguments to avoid confusing Toil code attempting to parse them
+        sys.argv[1:] = []
+        errno = pytest.main(self.pytest_args)
+        sys.exit(errno)
+
+kwargs['cmdclass'] = {'test': PyTest}
+
+setup(**kwargs)
+
+print("\n\nThank you for installing toil-scripts! If you want to run Toil in a cloud environment or on a distributed "
+      "system, please install Toil with the desired extras, for example:\n\n"
+      "'pip install toil[aws,mesos,azure,encryption]==%s'\n\n"
+      "Please take a look at Toil's documentation for more information: http://toil.readthedocs.io/en/releases-3.1.x/"
+      % toil_version)

--- a/version.py
+++ b/version.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2015 UCSC Computational Genomics Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version = '2.0a1'


### PR DESCRIPTION
Create setup.py
Add setup.cfg that points to README
Set version in version.py so it can be reached by Makefile and setup.py
Update README for installation and entrypoints
Create Makefile to handle PyPi distribution, tests, and cleaning
Modify Jenkins.sh to use Makefile