### PR TITLE
Update UNC readme (resolves #342)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,8 +68,6 @@ kwargs = dict(
         'console_scripts': [
             'toil-bwa = toil_scripts.batch_alignment.bwa_alignment:main',
             'toil-rnaseq = toil_scripts.rnaseq_cgl.rnaseq_cgl_pipeline:main',
-            'toil-rnaseq-unc = toil_scripts.rnaseq_unc.rnaseq_unc_pipeline:main',
-            'toil-spladder = toil_scripts.spladder_pipeline.spladder_pipeline:main',
             'toil-exome = toil_scripts.exome_variant_pipeline.exome_variant_pipeline:main']})
 
 

--- a/src/toil_scripts/rnaseq_unc/README.md
+++ b/src/toil_scripts/rnaseq_unc/README.md
@@ -1,9 +1,14 @@
 ## University of California, Santa Cruz Genomics Institute
 ### Guide: Running UNC Best Practices RNA-seq Pipeline using Toil
 
-This guide attempts to walk the user through running this pipeline from start to finish. If there are any questions
-please contact John Vivian (jtvivian@gmail.com). If you find any errors or corrections please feel free to make a 
-pull request.  Feedback of any kind is appreciated.
+**This pipeline has been deprecated in favor of the CGL RNA-seq pipeline, which is an order of magnitude faster
+and produces results that are concordant to this pipeline. If you'd still like to use this pipeline, you will need
+to use an earlier version of Toil**
+
+`pip install toil==3.1.6`
+
+This guide attempts to walk the user through running this pipeline from start to finish. 
+If you find any errors or corrections please feel free to make a pull request. Feedback of any kind is appreciated.
 
 ## Overview
 This pipeline accepts a sample.tar file (either by URL or locally) that contains RNA-seq fq.gz data files.  It assumes


### PR DESCRIPTION
@hannes-ucsc — Small PR.  UNC was deprecated as a production pipeline, is no longer compatible with  Toil 3.2.x, and the documentation was never updated to reflect that. 

A user emailed me with errors arising from caching, which is a conflict introduced in the move to 3.2.x.

