### PR TITLE
Convert RNASeq test to TestCase and randomize output (resolves #354)

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -13,9 +13,19 @@ virtualenv venv
 . venv/bin/activate
 # Adding AWS extra to get boto as required by tests
 pip install toil[aws]==3.3.0
+
+# Prepare directory for temp files
+TMPDIR=/mnt/ephemeral/tmp
+rm -rf $TMPDIR
+mkdir $TMPDIR
+export TMPDIR
+
 make develop
 make test
 make clean
+
 rm -rf bin s3am
 make pypi
 rm -rf venv
+
+rm -rf $TMPDIR

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -11,8 +11,8 @@ export PATH=$PATH:${PWD}/bin
 # Create Toil venv
 virtualenv venv
 . venv/bin/activate
-pip install toil==3.3.0
-pip install bd2k-python-lib==1.14a1.dev29
+# Adding AWS extra to get boto as required by tests
+pip install toil[aws]==3.3.0
 make develop
 make test
 make clean

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,14 +1,17 @@
 #!/usr/bin/env bash
 
 # Create s3am venv
+rm -rf s3am
 virtualenv s3am
 s3am/bin/pip install s3am==2.0a1.dev93
-# Expose binaries to the PATH
+# Expose s3am binary on the PATH
+rm -rf bin
 mkdir bin
 ln -snf ${PWD}/s3am/bin/s3am bin/
 export PATH=$PATH:${PWD}/bin
 
 # Create Toil venv
+rm -rf venv
 virtualenv venv
 . venv/bin/activate
 # Adding AWS extra to get boto as required by tests
@@ -24,8 +27,8 @@ make develop
 make test
 make clean
 
+# clean working copy to satisfy corresponding check in Makefile
 rm -rf bin s3am
 make pypi
-rm -rf venv
 
-rm -rf $TMPDIR
+rm -rf venv $TMPDIR

--- a/src/toil_scripts/bwa_alignment/test/test_bwa_alignment.py
+++ b/src/toil_scripts/bwa_alignment/test/test_bwa_alignment.py
@@ -1,25 +1,24 @@
+import tempfile
+
 import os
 import subprocess
 import shutil
 from boto.s3.connection import S3Connection, Bucket, Key
 
 
-def test_bwa(tmpdir):
-    work_dir = str(tmpdir)
+def test_bwa():
+    work_dir = tempfile.mkdtemp()
     create_config(work_dir)
     create_manifest(work_dir)
-    subdir = '/mnt/ephemeral/toil-scripts/bwa'
-    os.makedirs(os.path.join(subdir, 'workDir'))
     # Call Pipeline
     try:
         subprocess.check_call(['toil-bwa', 'run',
-                               os.path.join(subdir, 'jstore'),
+                               os.path.join(work_dir, 'jstore'),
                                '--manifest', os.path.join(work_dir, 'manifest.txt'),
                                '--config', os.path.join(work_dir, 'config.txt'),
-                               '--retryCount', '1',
-                               '--workDir', os.path.join(subdir, 'workDir')])
+                               '--retryCount', '1'])
     finally:
-        shutil.rmtree(subdir)
+        shutil.rmtree(work_dir)
         conn = S3Connection()
         b = Bucket(conn, 'cgl-driver-projects')
         k = Key(b)

--- a/src/toil_scripts/exome_variant_pipeline/test/test_exome.py
+++ b/src/toil_scripts/exome_variant_pipeline/test/test_exome.py
@@ -1,3 +1,5 @@
+import tempfile
+
 import os
 import shutil
 import subprocess
@@ -5,18 +7,15 @@ import textwrap
 
 from boto.s3.connection import S3Connection, Bucket, Key
 
-from toil_scripts.lib import get_work_directory
 
-
-def test_exome(tmpdir):
-    workdir = get_work_directory()
+def test_exome():
+    workdir = tempfile.mkdtemp()
     create_config_and_manifest(workdir)
     # Call Pipeline
     try:
         base_command = ['toil-exome', 'run',
                         '--config', os.path.join(workdir, 'config-toil-exome.yaml'),
-                        os.path.join(workdir, 'jstore'),
-                        '--workDir', workdir]
+                        os.path.join(workdir, 'jstore')]
         # Run with manifest
         subprocess.check_call(base_command + ['--manifest', os.path.join(workdir, 'manifest-toil-exome.tsv')])
     finally:

--- a/src/toil_scripts/lib/__init__.py
+++ b/src/toil_scripts/lib/__init__.py
@@ -35,23 +35,6 @@ def partitions(l, partition_size):
         yield l[i:i + partition_size]
 
 
-def get_work_directory():
-    """
-    Creates a a working directory at a location that is suitable for storing files
-    temporarily. The caller is responsible for removing the directory.
-
-    :return: The path to directory
-    :rtype: str
-    """
-    try:
-        basedir = os.environ['TOIL_WORKDIR']
-    except KeyError:
-        basedir = '/mnt/ephemeral'
-        if not os.path.exists(basedir):
-            basedir = None
-    return tempfile.mkdtemp(dir=basedir)
-
-
 class UserError(Exception):
     pass
 

--- a/src/toil_scripts/lib/test/test_jobs.py
+++ b/src/toil_scripts/lib/test/test_jobs.py
@@ -1,11 +1,12 @@
+import tempfile
+
 import os
 from toil.job import Job
-from toil_scripts.lib import get_work_directory
 
 
-def test_map_job(tmpdir):
+def test_map_job():
     from toil_scripts.lib.jobs import map_job
-    work_dir = get_work_directory()
+    work_dir = tempfile.mkdtemp()
     options = Job.Runner.getDefaultOptions(os.path.join(work_dir, 'test_store'))
     options.workDir = work_dir
     samples = [x for x in xrange(200)]

--- a/src/toil_scripts/rnaseq_cgl/test/test_rnaseq_cgl.py
+++ b/src/toil_scripts/rnaseq_cgl/test/test_rnaseq_cgl.py
@@ -1,6 +1,8 @@
 import logging
+import shlex
 import shutil
 import subprocess
+import tempfile
 import textwrap
 from contextlib import closing
 from unittest import TestCase
@@ -9,13 +11,25 @@ from uuid import uuid4
 
 import os
 import posixpath
+from bd2k.util.iterables import concat
 from boto.s3.connection import S3Connection, Bucket
-from toil_scripts.lib import get_work_directory
 
 log = logging.getLogger(__name__)
 
 
 class RNASeqCGLTest(TestCase):
+    """
+    These tests *can* be parameterized with the following optional environment variables:
+
+    TOIL_SCRIPTS_TEST_TOIL_OPTIONS - a space-separated list of additional command line arguments to pass to Toil via
+    the script entry point. Default is the empty string.
+
+    TOIL_SCRIPTS_TEST_JOBSTORE - the job store locator to use for the tests. The default is a file: locator pointing
+    at a local temporary directory.
+
+    TOIL_SCRIPTS_TEST_NUM_SAMPLES - the number of sample lines to generate in the input manifest
+    """
+
     @classmethod
     def setUpClass(cls):
         super(RNASeqCGLTest, cls).setUpClass()
@@ -26,28 +40,38 @@ class RNASeqCGLTest(TestCase):
         self.input_dir = urlparse('s3://cgl-pipeline-inputs/rnaseq_cgl/ci')
         self.output_dir = urlparse('s3://cgl-driver-projects/test/ci/%s' % uuid4())
         self.sample = urlparse(self.input_dir.geturl() + '/chr6_sample.tar.gz')
-        self.workdir = get_work_directory()
-        self.base_command = ['toil-rnaseq', 'run',
-                             '--config', self._generate_config(),
-                             os.path.join(self.workdir, 'jobstore'),
-                             '--retryCount', '1',
-                             '--workDir', self.workdir]
+        self.workdir = tempfile.mkdtemp()
+        jobStore = os.getenv('TOIL_SCRIPTS_TEST_JOBSTORE', os.path.join(self.workdir, 'jobstore-%s' % uuid4()))
+        toilOptions = shlex.split(os.environ.get('TOIL_SCRIPTS_TEST_TOIL_OPTIONS', ''))
+        self.base_command = concat('toil-rnaseq', 'run',
+                                   '--config', self._generate_config(),
+                                   '--retryCount', '1',
+                                   toilOptions,
+                                   jobStore)
 
-    def test_with_samples_option(self):
-        subprocess.check_call(self.base_command + ['--samples', self.sample.geturl()])
+    def test_samples_option(self):
+        self._run(self.base_command, '--samples', self.sample.geturl())
         self._assertOutput()
 
-    def test_with_manifest(self):
-        subprocess.check_call(self.base_command + ['--manifest', self._generate_manifest()])
-        self._assertOutput()
+    def test_manifest(self):
+        num_samples = int(os.environ.get('TOIL_SCRIPTS_TEST_NUM_SAMPLES', '1'))
+        self._run(self.base_command, '--manifest', self._generate_manifest(num_samples))
+        self._assertOutput(num_samples)
 
-    def _assertOutput(self):
+    def _run(self, *args):
+        args = list(concat(*args))
+        log.info('Running %r', args)
+        subprocess.check_call(args)
+
+    def _assertOutput(self, num_samples=None):
         with closing(S3Connection()) as s3:
             bucket = Bucket(s3, self.output_dir.netloc)
             prefix = self.output_dir.path[1:]
-            output_file = posixpath.basename(self.sample.path)
-            bucket.get_key(posixpath.join(prefix, output_file), validate=True)
-            # FIXME: We may want to validate the output a bit more
+            for i in range(1 if num_samples is None else num_samples):
+                output_file = self._sample_name(None if num_samples is None else i) + '.tar.gz'
+                key = bucket.get_key(posixpath.join(prefix, output_file), validate=True)
+                # FIXME: We may want to validate the output a bit more
+                self.assertTrue(key.size > 0)
 
     def tearDown(self):
         shutil.rmtree(self.workdir)
@@ -80,8 +104,18 @@ class RNASeqCGLTest(TestCase):
                                     input_dir=self.input_dir.geturl()))
         return path
 
-    def _generate_manifest(self):
+    def _generate_manifest(self, num_samples):
         path = os.path.join(self.workdir, 'manifest-toil-rnaseq.tsv')
         with open(path, 'w') as f:
-            f.write('\t'.join(['tar', 'paired', 'chr6_sample', self.sample.geturl()]))
+            f.write('\n'.join('\t'.join(['tar', 'paired', self._sample_name(i), self.sample.geturl()])
+                              for i in range(num_samples)))
         return path
+
+    def _sample_name(self, i=None):
+        uuid = posixpath.basename(self.sample.path).split('.')
+        while uuid[-1] in ('gz', 'tar', 'zip'):
+            uuid.pop()
+        uuid = '.'.join(uuid)
+        if i is not None:
+            uuid = '%s_%i' % (uuid, i)
+        return uuid

--- a/src/toil_scripts/rnaseq_cgl/test/test_rnaseq_cgl.py
+++ b/src/toil_scripts/rnaseq_cgl/test/test_rnaseq_cgl.py
@@ -3,7 +3,9 @@ import shutil
 import subprocess
 import textwrap
 from contextlib import closing
+from unittest import TestCase
 from urlparse import urlparse
+from uuid import uuid4
 
 import os
 import posixpath
@@ -12,77 +14,74 @@ from toil_scripts.lib import get_work_directory
 
 log = logging.getLogger(__name__)
 
-input_dir = urlparse('s3://cgl-pipeline-inputs/rnaseq_cgl/ci')
-output_dir = urlparse('s3://cgl-driver-projects/test/ci')
-sample = urlparse(input_dir.geturl() + '/chr6_sample.tar.gz')
 
+class RNASeqCGLTest(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(RNASeqCGLTest, cls).setUpClass()
+        # FIXME: pull up into common base class
+        logging.basicConfig(level=logging.INFO)
 
-def test_rnaseq_cgl():
-    logging.basicConfig(level=logging.INFO)  # FIXME: I wish we didn't have to do this here
-    workdir = get_work_directory()
-    try:
-        # Call Pipeline
-        base_command = ['toil-rnaseq', 'run',
-                        '--config', generate_config(workdir),
-                        os.path.join(workdir, 'jstore'),
-                        '--retryCount', '1',
-                        '--workDir', workdir]
-        # Run with --samples
-        try:
-            subprocess.check_call(base_command + ['--samples', sample.geturl()])
-        finally:
-            cleanup_and_validate()
-        # Run with manifest
-        try:
-            subprocess.check_call(base_command + ['--manifest', generate_manifest(workdir)])
-        finally:
-            cleanup_and_validate()
-    finally:
-        shutil.rmtree(workdir)
+    def setUp(self):
+        self.input_dir = urlparse('s3://cgl-pipeline-inputs/rnaseq_cgl/ci')
+        self.output_dir = urlparse('s3://cgl-driver-projects/test/ci/%s' % uuid4())
+        self.sample = urlparse(self.input_dir.geturl() + '/chr6_sample.tar.gz')
+        self.workdir = get_work_directory()
+        self.base_command = ['toil-rnaseq', 'run',
+                             '--config', self._generate_config(),
+                             os.path.join(self.workdir, 'jobstore'),
+                             '--retryCount', '1',
+                             '--workDir', self.workdir]
 
+    def test_with_samples_option(self):
+        subprocess.check_call(self.base_command + ['--samples', self.sample.geturl()])
+        self._assertOutput()
 
-def cleanup_and_validate():
-    valid_output = False
-    expected_output = posixpath.basename(sample.path)
-    with closing(S3Connection()) as s3:
-        b = Bucket(s3, output_dir.netloc)
-        path = output_dir.path[1:]
-        for k in b.list(prefix=path):
-            assert k.name.startswith(path)
-            if k.name[len(path):] == '/' + expected_output:
-                # FIXME: We may want to validate the output a bit more
-                valid_output = True
-            else:
-                log.warn('Unexpected output file %s/%s', output_dir.geturl(), k.name)
-            k.delete()
-    assert valid_output, 'Did not find expected output file'
+    def test_with_manifest(self):
+        subprocess.check_call(self.base_command + ['--manifest', self._generate_manifest()])
+        self._assertOutput()
 
+    def _assertOutput(self):
+        with closing(S3Connection()) as s3:
+            bucket = Bucket(s3, self.output_dir.netloc)
+            prefix = self.output_dir.path[1:]
+            output_file = posixpath.basename(self.sample.path)
+            bucket.get_key(posixpath.join(prefix, output_file), validate=True)
+            # FIXME: We may want to validate the output a bit more
 
-def generate_config(workdir):
-    path = os.path.join(workdir, 'config-toil-rnaseq.yaml')
-    with open(path, 'w') as f:
-        f.write(textwrap.dedent("""
-            star-index: {input_dir}/starIndex_chr6.tar.gz
-            kallisto-index: s3://cgl-pipeline-inputs/rnaseq_cgl/kallisto_hg38.idx
-            rsem-ref: {input_dir}/rsem_ref_chr6.tar.gz
-            output-dir:
-            s3-output-dir: {output_dir}
-            fastqc: true
-            cutadapt:
-            ssec:
-            gtkey:
-            wiggle:
-            save-bam:
-            fwd-3pr-adapter: AGATCGGAAGAG
-            rev-3pr-adapter: AGATCGGAAGAG
-            ci-test: true
-            """[1:]).format(output_dir=output_dir.geturl(),
-                            input_dir=input_dir.geturl()))
-    return path
+    def tearDown(self):
+        shutil.rmtree(self.workdir)
+        with closing(S3Connection()) as s3:
+            bucket = Bucket(s3, self.output_dir.netloc)
+            prefix = self.output_dir.path[1:]
+            for key in bucket.list(prefix=prefix):
+                assert key.name.startswith(prefix)
+                key.delete()
 
+    def _generate_config(self):
+        path = os.path.join(self.workdir, 'config-toil-rnaseq.yaml')
+        with open(path, 'w') as f:
+            f.write(textwrap.dedent("""
+                    star-index: {input_dir}/starIndex_chr6.tar.gz
+                    kallisto-index: s3://cgl-pipeline-inputs/rnaseq_cgl/kallisto_hg38.idx
+                    rsem-ref: {input_dir}/rsem_ref_chr6.tar.gz
+                    output-dir:
+                    s3-output-dir: {output_dir}
+                    fastqc: true
+                    cutadapt:
+                    ssec:
+                    gtkey:
+                    wiggle:
+                    save-bam:
+                    fwd-3pr-adapter: AGATCGGAAGAG
+                    rev-3pr-adapter: AGATCGGAAGAG
+                    ci-test: true
+                    """[1:]).format(output_dir=self.output_dir.geturl(),
+                                    input_dir=self.input_dir.geturl()))
+        return path
 
-def generate_manifest(workdir):
-    path = os.path.join(workdir, 'manifest-toil-rnaseq.tsv')
-    with open(path, 'w') as f:
-        f.write('\t'.join(['tar', 'paired', 'chr6_sample', sample.geturl()]))
-    return path
+    def _generate_manifest(self):
+        path = os.path.join(self.workdir, 'manifest-toil-rnaseq.tsv')
+        with open(path, 'w') as f:
+            f.write('\t'.join(['tar', 'paired', 'chr6_sample', self.sample.geturl()]))
+        return path


### PR DESCRIPTION
Using a class-based unit test just makes it easier to control what is initialized at which stage of the the test lifecycle. It also should open us up to provide a shared TestCase base class in toil-lib.