### PR TITLE
Refer to proper version of toil-lib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ kwargs = dict(
     author_email='cgl-toil@googlegroups.com',
     url="https://github.com/BD2KGenomics/toil-scripts",
     install_requires=[
-        'toil-lib==1.0.4a1.dev55',
+        'toil-lib==1.1.0a1.dev52',
         'pyyaml==3.11'],
     tests_require=[
         'pytest==2.8.3'],


### PR DESCRIPTION
The proper version was hidden on Pypi. @hannes-ucsc fixed that and this change updates the wrong version included in #463 